### PR TITLE
Fixed issue where using templates would cause "double binding" for event bindings

### DIFF
--- a/UnityWeld/Binding/AbstractMemberBinding.cs
+++ b/UnityWeld/Binding/AbstractMemberBinding.cs
@@ -161,7 +161,7 @@ namespace UnityWeld.Binding
 
         protected void Awake()
         {
-            Connect();
+            Init();
         }
 
         /// <summary>


### PR DESCRIPTION
- In AbstractMemberBinding.cs the Awake() method was calling Connect(); and the templates would again do the same thing, resulting in event bindings firing twice when using templates
- Changed it to Init(); So, it disconnects, then connects