### PR TITLE
Fixing issues with some unity components

### DIFF
--- a/UnityWeld/Binding/AbstractMemberBinding.cs
+++ b/UnityWeld/Binding/AbstractMemberBinding.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using UnityEngine;
 using UnityWeld.Binding.Exceptions;
@@ -117,6 +117,11 @@ namespace UnityWeld.Binding
 
             typeName = endPointReference.Substring(0, lastPeriodIndex);
             memberName = endPointReference.Substring(lastPeriodIndex + 1);
+            if (typeName.StartsWith("UnityEngine."))
+            {
+                lastPeriodIndex = typeName.LastIndexOf('.');
+                typeName = typeName.Substring(lastPeriodIndex + 1);
+            }
             if (typeName.Length == 0 || memberName.Length == 0)
             {
                 throw new InvalidEndPointException(

--- a/UnityWeld/Binding/AbstractMemberBinding.cs
+++ b/UnityWeld/Binding/AbstractMemberBinding.cs
@@ -117,10 +117,11 @@ namespace UnityWeld.Binding
 
             typeName = endPointReference.Substring(0, lastPeriodIndex);
             memberName = endPointReference.Substring(lastPeriodIndex + 1);
+            //Due to (undocumented) unity behaviour, some of their components do not work with the namespace when using GetComponent(""), and all of them work without the namespace
+            //So to be safe, we remove all namespaces from any component that starts with UnityEngine
             if (typeName.StartsWith("UnityEngine."))
             {
-                lastPeriodIndex = typeName.LastIndexOf('.');
-                typeName = typeName.Substring(lastPeriodIndex + 1);
+                typeName = typeName.Substring(typeName.LastIndexOf('.') + 1);
             }
             if (typeName.Length == 0 || memberName.Length == 0)
             {


### PR DESCRIPTION
on ParseEndPointReference in AbstractMemberBinding, if the components namespace starts with "UnityEngine", it removes the namespace and just uses the component name

I've noticed using GetComponent("") will not work for all unity components if you include the namespace (in my case, RectTransform), however using GetComponent("") and removing all unity namespaces still works on all unity components, so if a component starts with "UnityEngine." I remove all namespaces. Everything still seems to work fine, and you can now bind to RectTransform properties