### PR TITLE
Fixed issue with modified fields not being detected, improved adapter support for ToggleActiveBinding

### DIFF
--- a/UnityWeld/Binding/AbstractTemplateSelector.cs
+++ b/UnityWeld/Binding/AbstractTemplateSelector.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -18,7 +18,14 @@ namespace UnityWeld.Binding
         /// <summary>
         /// The name of the property we are binding to on the view model.
         /// </summary>
-        public string viewModelPropertyName = string.Empty;
+        public string ViewModelPropertyName
+        {
+            get { return viewModelPropertyName; }
+            set { viewModelPropertyName = value; }
+        }
+
+        [SerializeField]
+        private string viewModelPropertyName = string.Empty;
 
         /// <summary>
         /// Watches the view-model property for changes.
@@ -26,9 +33,16 @@ namespace UnityWeld.Binding
         protected PropertyWatcher viewModelPropertyWatcher;
 
         /// <summary>
-        /// The gameobject in the scene that is the parent object for the tenplates.
+        /// The GameObject in the scene that is the parent object for the tenplates.
         /// </summary>
-        public GameObject templatesRoot;
+        public GameObject TemplatesRoot
+        {
+            get { return templatesRoot; }
+            set { templatesRoot = value; }
+        }
+
+        [SerializeField]
+        private GameObject templatesRoot;
 
         /// <summary>
         /// All available templates indexed by the view model the are for.

--- a/UnityWeld/Binding/CollectionBinding.cs
+++ b/UnityWeld/Binding/CollectionBinding.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Linq;
 using UnityEngine;
@@ -21,11 +21,19 @@ namespace UnityWeld.Binding
 
             string propertyName;
             object newViewModel;
-            ParseViewModelEndPointReference(viewModelPropertyName, out propertyName, out newViewModel);
+            ParseViewModelEndPointReference(
+                ViewModelPropertyName, 
+                out propertyName, 
+                out newViewModel
+            );
 
             viewModel = newViewModel;
 
-            viewModelPropertyWatcher = new PropertyWatcher(newViewModel, propertyName, NotifyPropertyChanged_PropertyChanged);
+            viewModelPropertyWatcher = new PropertyWatcher(
+                newViewModel, 
+                propertyName, 
+                NotifyPropertyChanged_PropertyChanged
+            );
 
             BindCollection();
         }
@@ -105,24 +113,39 @@ namespace UnityWeld.Binding
 
             string propertyName;
             string viewModelName;
-            ParseEndPointReference(viewModelPropertyName, out propertyName, out viewModelName);
+            ParseEndPointReference(
+                ViewModelPropertyName, 
+                out propertyName, 
+                out viewModelName
+            );
 
             var viewModelCollectionProperty = viewModelType.GetProperty(propertyName);
             if (viewModelCollectionProperty == null)
             {
-                throw new MemberNotFoundException("Expected property " + viewModelPropertyName + ", but it wasn't found on type " + viewModelType + ".");
+                throw new MemberNotFoundException(
+                    "Expected property " 
+                    + ViewModelPropertyName + ", but it wasn't found on type " 
+                    + viewModelType + "."
+                );
             }
 
             // Get value from view model.
             var viewModelValue = viewModelCollectionProperty.GetValue(viewModel, null);
             if (viewModelValue == null)
             {
-                throw new PropertyNullException("Cannot bind to null property in view: " + viewModelPropertyName);
+                throw new PropertyNullException(
+                    "Cannot bind to null property in view: " 
+                    + ViewModelPropertyName
+                );
             }
 
             if (!(viewModelValue is IEnumerable))
             {
-                throw new InvalidTypeException("Property " + viewModelPropertyName + " is not a collection and cannot be used to bind collections.");
+                throw new InvalidTypeException(
+                    "Property " 
+                    + ViewModelPropertyName 
+                    + " is not a collection and cannot be used to bind collections."
+                );
             }
             viewModelCollectionValue = (IEnumerable)viewModelValue;
 

--- a/UnityWeld/Binding/CollectionBinding.cs
+++ b/UnityWeld/Binding/CollectionBinding.cs
@@ -7,6 +7,13 @@ using UnityWeld.Binding.Internal;
 
 namespace UnityWeld.Binding
 {
+    /// <summary>
+    /// Binds a property in the view-model that is a collection and instantiates copies
+    /// of template objects to bind to the items of the collection.
+    /// 
+    /// Creates and destroys child objects when items are added and removed from a 
+    /// collection that implements INotifyCollectionChanged, like ObservableList.
+    /// </summary>
     [HelpURL("https://github.com/Real-Serious-Games/Unity-Weld")]
     public class CollectionBinding : AbstractTemplateSelector
     {

--- a/UnityWeld/Binding/EventBinding.cs
+++ b/UnityWeld/Binding/EventBinding.cs
@@ -44,7 +44,11 @@ namespace UnityWeld.Binding
         {
             string methodName;
             object viewModel;
-            ParseViewModelEndPointReference(viewModelMethodName, out methodName, out viewModel);
+            ParseViewModelEndPointReference(
+                viewModelMethodName, 
+                out methodName, 
+                out viewModel
+            );
             var viewModelMethod = viewModel.GetType().GetMethod(methodName, new Type[0]);
 
             string eventName;

--- a/UnityWeld/Binding/OneWayPropertyBinding.cs
+++ b/UnityWeld/Binding/OneWayPropertyBinding.cs
@@ -13,7 +13,8 @@ namespace UnityWeld.Binding
     public class OneWayPropertyBinding : AbstractMemberBinding
     {
         /// <summary>
-        /// Type of the adapter we're using to adapt between the view model property and UI property.
+        /// Type of the adapter we're using to adapt between the view model property 
+        /// and UI property.
         /// </summary>
         public string ViewAdapterTypeName
         {

--- a/UnityWeld/Binding/TemplateBinding.cs
+++ b/UnityWeld/Binding/TemplateBinding.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using UnityEngine;
 using UnityWeld.Binding.Exceptions;
@@ -25,17 +25,27 @@ namespace UnityWeld.Binding
             Disconnect();
 
             string propertyName;
-            ParseViewModelEndPointReference(viewModelPropertyName, out propertyName, out viewModel);
+            ParseViewModelEndPointReference(
+                ViewModelPropertyName, 
+                out propertyName, 
+                out viewModel
+            );
 
-            viewModelPropertyWatcher = new PropertyWatcher(viewModel, propertyName, InitalizeTemplate);
+            viewModelPropertyWatcher = new PropertyWatcher(
+                viewModel, 
+                propertyName, 
+                InitalizeTemplate
+            );
 
             // Get property from view model.
             viewModelProperty = viewModel.GetType().GetProperty(propertyName);
             if (viewModelProperty == null)
             {
-                throw new MemberNotFoundException(
-                    string.Format("Expected property {0} on type {1}, but was not found.", propertyName, viewModel.GetType().Name)
-                );
+                throw new MemberNotFoundException(string.Format(
+                    "Expected property {0} on type {1}, but was not found.", 
+                    propertyName, 
+                    viewModel.GetType().Name
+                ));
             }
 
             InitalizeTemplate();
@@ -69,7 +79,10 @@ namespace UnityWeld.Binding
             var viewModelPropertyValue = viewModelProperty.GetValue(viewModel, null);
             if (viewModelPropertyValue == null)
             {
-                throw new PropertyNullException(string.Format("TemplateBinding cannot bind to null property in view: {0}.", viewModelPropertyName));
+                throw new PropertyNullException(string.Format(
+                    "TemplateBinding cannot bind to null property in view: {0}.", 
+                    ViewModelPropertyName
+                ));
             }
 
             InstantiateTemplate(viewModelPropertyValue);

--- a/UnityWeld/Binding/ToggleActiveBinding.cs
+++ b/UnityWeld/Binding/ToggleActiveBinding.cs
@@ -14,7 +14,8 @@ namespace UnityWeld.Binding
     public class ToggleActiveBinding : AbstractMemberBinding
     {
         /// <summary>
-        /// Type of the adapter we're using to adapt between the view model property and UI property.
+        /// Type of the adapter we're using to adapt between the view model property 
+        /// and view property.
         /// </summary>
         public string ViewAdapterTypeName
         {
@@ -26,7 +27,7 @@ namespace UnityWeld.Binding
         private string viewAdapterTypeName;
 
         /// <summary>
-        /// Options for adapting from the view model to the UI property.
+        /// Options for adapting from the view model to the view property.
         /// </summary>
         public AdapterOptions ViewAdapterOptions
         {

--- a/UnityWeld/Binding/ToggleActiveBinding.cs
+++ b/UnityWeld/Binding/ToggleActiveBinding.cs
@@ -70,11 +70,6 @@ namespace UnityWeld.Binding
         {
             var viewModelEndPoint = MakeViewModelEndPoint(viewModelPropertyName, null, null);
 
-            Assert.IsTrue(
-                viewModelEndPoint.GetValue() is bool,
-                "ToggleActiveBinding can only be bound to a boolean property."
-            );
-
             var propertySync = new PropertySync(
                 // Source
                 viewModelEndPoint,

--- a/UnityWeld/Binding/TwoWayPropertyBinding.cs
+++ b/UnityWeld/Binding/TwoWayPropertyBinding.cs
@@ -150,7 +150,11 @@ namespace UnityWeld.Binding
             Component view;
             ParseViewEndPointReference(viewPropertyName, out propertyName, out view);
 
-            var viewModelEndPoint = MakeViewModelEndPoint(viewModelPropertyName, viewModelAdapterTypeName, viewModelAdapterOptions);
+            var viewModelEndPoint = MakeViewModelEndPoint(
+                viewModelPropertyName, 
+                viewModelAdapterTypeName, 
+                viewModelAdapterOptions
+            );
 
             var propertySync = new PropertySync(
                 // Source
@@ -168,7 +172,11 @@ namespace UnityWeld.Binding
 
                 // Errors, exceptions and validation.
                 !string.IsNullOrEmpty(exceptionPropertyName)
-                    ? MakeViewModelEndPoint(exceptionPropertyName, exceptionAdapterTypeName, exceptionAdapterOptions)
+                    ? MakeViewModelEndPoint(
+                        exceptionPropertyName, 
+                        exceptionAdapterTypeName, 
+                        exceptionAdapterOptions
+                      )
                     : null
                     ,
                 

--- a/UnityWeld_Editor/CollectionBindingEditor.cs
+++ b/UnityWeld_Editor/CollectionBindingEditor.cs
@@ -1,4 +1,4 @@
-﻿using UnityEditor;
+using UnityEditor;
 using UnityEngine;
 using UnityWeld.Binding;
 using UnityWeld.Binding.Internal;
@@ -29,19 +29,19 @@ namespace UnityWeld_Editor
             ShowViewModelPropertyMenu(
                 new GUIContent("View-model property", "Property on the view-model to bind to."),
                 TypeResolver.FindBindableCollectionProperties(targetScript),
-                updatedValue => targetScript.viewModelPropertyName = updatedValue,
-                targetScript.viewModelPropertyName,
+                updatedValue => targetScript.ViewModelPropertyName = updatedValue,
+                targetScript.ViewModelPropertyName,
                 property => true
             );
 
             EditorStyles.label.fontStyle = templatesRootPrefabModified ? FontStyle.Bold : defaultLabelStyle;
 
             UpdateProperty(
-                updatedValue => targetScript.templatesRoot = updatedValue,
-                targetScript.templatesRoot,
+                updatedValue => targetScript.TemplatesRoot = updatedValue,
+                targetScript.TemplatesRoot,
                 (GameObject)EditorGUILayout.ObjectField(
                     new GUIContent("Collection templates", "Parent object for all templates to copy and bind to items in the collection."), 
-                    targetScript.templatesRoot, 
+                    targetScript.TemplatesRoot, 
                     typeof(GameObject), 
                     true
                 ),

--- a/UnityWeld_Editor/EventBindingEditor.cs
+++ b/UnityWeld_Editor/EventBindingEditor.cs
@@ -82,7 +82,7 @@ namespace UnityWeld_Editor
             {
                 switch (property.name)
                 {
-                    case "uiEventName":
+                    case "viewEventName":
                         viewEventPrefabModified = property.prefabOverride;
                         break;
 

--- a/UnityWeld_Editor/OneWayPropertyBindingEditor.cs
+++ b/UnityWeld_Editor/OneWayPropertyBindingEditor.cs
@@ -172,7 +172,7 @@ namespace UnityWeld_Editor
                         viewModelPropertyPrefabModified = property.prefabOverride;
                         break;
 
-                    case "uiPropertyName":
+                    case "viewPropertyName":
                         viewPropertyPrefabModified = property.prefabOverride;
                         break;
 

--- a/UnityWeld_Editor/OneWayPropertyBindingEditor.cs
+++ b/UnityWeld_Editor/OneWayPropertyBindingEditor.cs
@@ -45,7 +45,9 @@ namespace UnityWeld_Editor
             UpdatePrefabModifiedProperties();
 
             var defaultLabelStyle = EditorStyles.label.fontStyle;
-            EditorStyles.label.fontStyle = viewPropertyPrefabModified ? FontStyle.Bold : defaultLabelStyle;
+            EditorStyles.label.fontStyle = viewPropertyPrefabModified 
+                ? FontStyle.Bold 
+                : defaultLabelStyle;
 
             Type viewPropertyType;
             ShowViewPropertyMenu(
@@ -71,10 +73,15 @@ namespace UnityWeld_Editor
                     TypeResolver.FindAdapterAttribute(type).OutputType == viewPropertyType
             );
 
-            EditorStyles.label.fontStyle = viewAdapterPrefabModified ? FontStyle.Bold : defaultLabelStyle;
+            EditorStyles.label.fontStyle = viewAdapterPrefabModified 
+                ? FontStyle.Bold 
+                : defaultLabelStyle;
 
             ShowAdapterMenu(
-                new GUIContent("View adapter", "Adapter that converts values sent from the view-model to the view."),
+                new GUIContent(
+                    "View adapter", 
+                    "Adapter that converts values sent from the view-model to the view."
+                ),
                 viewAdapterTypeNames,
                 targetScript.ViewAdapterTypeName,
                 newValue =>
@@ -96,9 +103,14 @@ namespace UnityWeld_Editor
             );
 
             Type adapterType;
-            viewAdapterOptionsFade.target = ShouldShowAdapterOptions(targetScript.ViewAdapterTypeName, out adapterType);
+            viewAdapterOptionsFade.target = ShouldShowAdapterOptions(
+                targetScript.ViewAdapterTypeName, 
+                out adapterType
+            );
 
-            EditorStyles.label.fontStyle = viewAdapterOptionsPrefabModified ? FontStyle.Bold : defaultLabelStyle;
+            EditorStyles.label.fontStyle = viewAdapterOptionsPrefabModified 
+                ? FontStyle.Bold 
+                : defaultLabelStyle;
 
             ShowAdapterOptionsMenu(
                 "View adapter options", 
@@ -110,11 +122,19 @@ namespace UnityWeld_Editor
 
             EditorGUILayout.Space();
 
-            EditorStyles.label.fontStyle = viewModelPropertyPrefabModified ? FontStyle.Bold : defaultLabelStyle;
+            EditorStyles.label.fontStyle = viewModelPropertyPrefabModified 
+                ? FontStyle.Bold 
+                : defaultLabelStyle;
 
-            var adaptedViewPropertyType = AdaptTypeBackward(viewPropertyType, targetScript.ViewAdapterTypeName);
+            var adaptedViewPropertyType = AdaptTypeBackward(
+                viewPropertyType, 
+                targetScript.ViewAdapterTypeName
+            );
             ShowViewModelPropertyMenu(
-                new GUIContent("View-model property", "Property on the view-model to bind to."),
+                new GUIContent(
+                    "View-model property", 
+                    "Property on the view-model to bind to."
+                ),
                 TypeResolver.FindBindableProperties(targetScript),
                 updatedValue => targetScript.ViewModelPropertyName = updatedValue,
                 targetScript.ViewModelPropertyName,
@@ -127,7 +147,8 @@ namespace UnityWeld_Editor
         }
 
         /// <summary>
-        /// Check whether each of the properties on the object have been changed from the value in the prefab.
+        /// Check whether each of the properties on the object have been changed 
+        /// from the value in the prefab.
         /// </summary>
         private void UpdatePrefabModifiedProperties()
         {

--- a/UnityWeld_Editor/SubViewModelBindingEditor.cs
+++ b/UnityWeld_Editor/SubViewModelBindingEditor.cs
@@ -32,10 +32,15 @@ namespace UnityWeld_Editor
             var bindableProperties = FindBindableProperties();
 
             var defaultLabelStyle = EditorStyles.label.fontStyle;
-            EditorStyles.label.fontStyle = propertyPrefabModified ? FontStyle.Bold : defaultLabelStyle;
+            EditorStyles.label.fontStyle = propertyPrefabModified 
+                ? FontStyle.Bold 
+                : defaultLabelStyle;
 
             ShowViewModelPropertyMenu(
-                new GUIContent("Sub view-model property", "The property on the top level view model containing the sub view-model"),
+                new GUIContent(
+                    "Sub view-model property", 
+                    "The property on the top level view model containing the sub view-model"
+                ),
                 bindableProperties,
                 updatedValue => 
                 {
@@ -64,7 +69,8 @@ namespace UnityWeld_Editor
         }
 
         /// <summary>
-        /// Check whether each of the properties on the object have been changed from the value in the prefab.
+        /// Check whether each of the properties on the object have been changed 
+        /// from the value in the prefab.
         /// </summary>
         private void UpdatePrefabModifiedProperties()
         {
@@ -80,7 +86,8 @@ namespace UnityWeld_Editor
                 {
                     case "viewModelPropertyName": 
                     case "viewModelTypeName":
-                        propertyPrefabModified = property.prefabOverride || propertyPrefabModified;
+                        propertyPrefabModified = property.prefabOverride 
+                            || propertyPrefabModified;
                         break;
 
                     default:

--- a/UnityWeld_Editor/TemplateBindingEditor.cs
+++ b/UnityWeld_Editor/TemplateBindingEditor.cs
@@ -1,4 +1,4 @@
-﻿using UnityEditor;
+using UnityEditor;
 using UnityEngine;
 using UnityWeld.Binding;
 using UnityWeld.Binding.Internal;
@@ -28,19 +28,19 @@ namespace UnityWeld_Editor
             ShowViewModelPropertyMenu(
                 new GUIContent("Template property", "Property on the view model to use for selecting templates."),
                 TypeResolver.FindBindableProperties(targetScript),
-                updatedValue => targetScript.viewModelPropertyName = updatedValue,
-                targetScript.viewModelPropertyName,
+                updatedValue => targetScript.ViewModelPropertyName = updatedValue,
+                targetScript.ViewModelPropertyName,
                 property => true
             );
 
             EditorStyles.label.fontStyle = templatesRootPrefabModified ? FontStyle.Bold : defaultLabelStyle;
 
             UpdateProperty(
-                updatedValue => targetScript.templatesRoot = updatedValue,
-                targetScript.templatesRoot,
+                updatedValue => targetScript.TemplatesRoot = updatedValue,
+                targetScript.TemplatesRoot,
                 (GameObject)EditorGUILayout.ObjectField(
                     new GUIContent("Templates root object", "Parent object to the objects we want to use as templates."),
-                    targetScript.templatesRoot, 
+                    targetScript.TemplatesRoot, 
                     typeof(GameObject), 
                     true
                 ),

--- a/UnityWeld_Editor/TemplateBindingEditor.cs
+++ b/UnityWeld_Editor/TemplateBindingEditor.cs
@@ -23,23 +23,33 @@ namespace UnityWeld_Editor
             UpdatePrefabModifiedProperties();
 
             var defaultLabelStyle = EditorStyles.label.fontStyle;
-            EditorStyles.label.fontStyle = viewModelPrefabModified ? FontStyle.Bold : defaultLabelStyle;
+            EditorStyles.label.fontStyle = viewModelPrefabModified 
+                ? FontStyle.Bold 
+                : defaultLabelStyle;
 
             ShowViewModelPropertyMenu(
-                new GUIContent("Template property", "Property on the view model to use for selecting templates."),
+                new GUIContent(
+                    "Template property", 
+                    "Property on the view model to use for selecting templates."
+                ),
                 TypeResolver.FindBindableProperties(targetScript),
                 updatedValue => targetScript.ViewModelPropertyName = updatedValue,
                 targetScript.ViewModelPropertyName,
                 property => true
             );
 
-            EditorStyles.label.fontStyle = templatesRootPrefabModified ? FontStyle.Bold : defaultLabelStyle;
+            EditorStyles.label.fontStyle = templatesRootPrefabModified 
+                ? FontStyle.Bold 
+                : defaultLabelStyle;
 
             UpdateProperty(
                 updatedValue => targetScript.TemplatesRoot = updatedValue,
                 targetScript.TemplatesRoot,
                 (GameObject)EditorGUILayout.ObjectField(
-                    new GUIContent("Templates root object", "Parent object to the objects we want to use as templates."),
+                    new GUIContent(
+                        "Templates root object", 
+                        "Parent object to the objects we want to use as templates."
+                    ),
                     targetScript.TemplatesRoot, 
                     typeof(GameObject), 
                     true
@@ -51,7 +61,8 @@ namespace UnityWeld_Editor
         }
 
         /// <summary>
-        /// Check whether each of the properties on the object have been changed from the value in the prefab.
+        /// Check whether each of the properties on the object have been changed 
+        /// from the value in the prefab.
         /// </summary>
         private void UpdatePrefabModifiedProperties()
         {

--- a/UnityWeld_Editor/TemplateEditor.cs
+++ b/UnityWeld_Editor/TemplateEditor.cs
@@ -35,22 +35,36 @@ namespace UnityWeld_Editor
                 .OrderBy(name => name)
                 .ToArray();
 
-            var selectedIndex = Array.IndexOf(availableViewModels, targetScript.ViewModelTypeName);
+            var selectedIndex = Array.IndexOf(
+                availableViewModels, 
+                targetScript.ViewModelTypeName
+            );
 
             var defaultLabelStyle = EditorStyles.label.fontStyle;
-            EditorStyles.label.fontStyle = propertyPrefabModified ? FontStyle.Bold : defaultLabelStyle;
+            EditorStyles.label.fontStyle = propertyPrefabModified 
+                ? FontStyle.Bold 
+                : defaultLabelStyle;
 
             var newSelectedIndex = EditorGUILayout.Popup(
-                new GUIContent("Template view model", "Type of the view model that this template will be bound to when it is instantiated."),
+                new GUIContent(
+                    "Template view model", 
+                    "Type of the view model that this template will be bound to when it is instantiated."
+                ),
                 selectedIndex,
-                availableViewModels.Select(viewModel => new GUIContent(viewModel)).ToArray()
+                availableViewModels
+                    .Select(viewModel => new GUIContent(viewModel))
+                    .ToArray()
             );
 
             EditorStyles.label.fontStyle = defaultLabelStyle;
 
             UpdateProperty(newValue => targetScript.ViewModelTypeName = newValue,
-                selectedIndex < 0 ? string.Empty : availableViewModels[selectedIndex],
-                newSelectedIndex < 0 ? string.Empty : availableViewModels[newSelectedIndex],
+                selectedIndex < 0 
+                    ? string.Empty 
+                    : availableViewModels[selectedIndex],
+                newSelectedIndex < 0 
+                    ? string.Empty 
+                    : availableViewModels[newSelectedIndex],
                 "Set bound view-model for template"
             );
         }

--- a/UnityWeld_Editor/ToggleActiveBindingEditor.cs
+++ b/UnityWeld_Editor/ToggleActiveBindingEditor.cs
@@ -15,6 +15,10 @@ namespace UnityWeld_Editor
 
         private AnimBool viewAdapterOptionsFade;
 
+        private bool viewAdapterPrefabModified;
+        private bool viewAdapterOptionsPrefabModified;
+        private bool viewModelPropertyPrefabModified;
+
         private void OnEnable()
         {
             targetScript = (ToggleActiveBinding)target;
@@ -35,6 +39,8 @@ namespace UnityWeld_Editor
 
         public override void OnInspectorGUI()
         {
+            UpdatePrefabModifiedProperties();
+
             var defaultLabelStyle = EditorStyles.label.fontStyle;
 
             Type viewPropertyType = typeof(bool);
@@ -44,7 +50,7 @@ namespace UnityWeld_Editor
                     TypeResolver.FindAdapterAttribute(type).OutputType == viewPropertyType
             );
 
-            EditorStyles.label.fontStyle = DoesFieldOverridePrefab() 
+            EditorStyles.label.fontStyle = viewAdapterPrefabModified
                 ? FontStyle.Bold 
                 : defaultLabelStyle;
 
@@ -73,7 +79,7 @@ namespace UnityWeld_Editor
                 }
             );
 
-            EditorStyles.label.fontStyle = DoesFieldOverridePrefab() 
+            EditorStyles.label.fontStyle = viewModelPropertyPrefabModified
                 ? FontStyle.Bold 
                 : defaultLabelStyle;
 
@@ -95,7 +101,7 @@ namespace UnityWeld_Editor
             EditorStyles.label.fontStyle = defaultLabelStyle;
         }
 
-        private bool DoesFieldOverridePrefab()
+        private void UpdatePrefabModifiedProperties()
         {
             var property = serializedObject.GetIterator();
             // Need to call Next(true) to get the first child. Once we have it, Next(false)
@@ -103,16 +109,25 @@ namespace UnityWeld_Editor
             property.Next(true);
             do
             {
-                if (property.name == "viewModelPropertyName")
+                switch (property.name)
                 {
-                    return property.prefabOverride;
+                    case "viewAdapterTypeName":
+                        viewAdapterPrefabModified = property.prefabOverride;
+                        break;
+
+                    case "viewAdapterOptions":
+                        viewAdapterOptionsPrefabModified = property.prefabOverride;
+                        break;
+
+                    case "viewModelPropertyName":
+                        viewModelPropertyPrefabModified = property.prefabOverride;
+                        break;
+
+                    default:
+                        break;
                 }
             }
             while (property.Next(false));
-
-            throw new MemberNotFoundException(
-                "Field \"viewModelPropertyName\" not found on ToggleActiveBindingEditor."
-            );
         }
     }
 }

--- a/UnityWeld_Editor/ToggleActiveBindingEditor.cs
+++ b/UnityWeld_Editor/ToggleActiveBindingEditor.cs
@@ -79,6 +79,26 @@ namespace UnityWeld_Editor
                 }
             );
 
+            Type adapterType;
+            viewAdapterOptionsFade.target = ShouldShowAdapterOptions(
+                targetScript.ViewAdapterTypeName,
+                out adapterType
+            );
+
+            EditorStyles.label.fontStyle = viewAdapterOptionsPrefabModified
+                ? FontStyle.Bold
+                : defaultLabelStyle;
+
+            ShowAdapterOptionsMenu(
+                "View adapter options",
+                adapterType,
+                options => targetScript.ViewAdapterOptions = options,
+                targetScript.ViewAdapterOptions,
+                viewAdapterOptionsFade.faded
+            );
+
+            EditorGUILayout.Space();
+
             EditorStyles.label.fontStyle = viewModelPropertyPrefabModified
                 ? FontStyle.Bold 
                 : defaultLabelStyle;

--- a/UnityWeld_Editor/ToggleActiveBindingEditor.cs
+++ b/UnityWeld_Editor/ToggleActiveBindingEditor.cs
@@ -44,10 +44,15 @@ namespace UnityWeld_Editor
                     TypeResolver.FindAdapterAttribute(type).OutputType == viewPropertyType
             );
 
-            EditorStyles.label.fontStyle = DoesFieldOverridePrefab() ? FontStyle.Bold : defaultLabelStyle;
+            EditorStyles.label.fontStyle = DoesFieldOverridePrefab() 
+                ? FontStyle.Bold 
+                : defaultLabelStyle;
 
             ShowAdapterMenu(
-                new GUIContent("View adapter", "Adapter that converts values sent from the view-model to the view."),
+                new GUIContent(
+                    "View adapter", 
+                    "Adapter that converts values sent from the view-model to the view."
+                ),
                 viewAdapterTypeNames,
                 targetScript.ViewAdapterTypeName,
                 newValue =>
@@ -68,11 +73,19 @@ namespace UnityWeld_Editor
                 }
             );
 
-            EditorStyles.label.fontStyle = DoesFieldOverridePrefab() ? FontStyle.Bold : defaultLabelStyle;
+            EditorStyles.label.fontStyle = DoesFieldOverridePrefab() 
+                ? FontStyle.Bold 
+                : defaultLabelStyle;
 
-            var adaptedViewPropertyType = AdaptTypeBackward(viewPropertyType, targetScript.ViewAdapterTypeName);
+            var adaptedViewPropertyType = AdaptTypeBackward(
+                viewPropertyType, 
+                targetScript.ViewAdapterTypeName
+            );
             ShowViewModelPropertyMenu(
-                new GUIContent("View-model property", "Property on the view-model to bind to."),
+                new GUIContent(
+                    "View-model property", 
+                    "Property on the view-model to bind to."
+                ),
                 TypeResolver.FindBindableProperties(targetScript),
                 updatedValue => targetScript.ViewModelPropertyName = updatedValue,
                 targetScript.ViewModelPropertyName,
@@ -97,7 +110,9 @@ namespace UnityWeld_Editor
             }
             while (property.Next(false));
 
-            throw new MemberNotFoundException("Field \"viewModelPropertyName\" not found on ToggleActiveBindingEditor.");
+            throw new MemberNotFoundException(
+                "Field \"viewModelPropertyName\" not found on ToggleActiveBindingEditor."
+            );
         }
     }
 }

--- a/UnityWeld_Editor/TwoWayPropertyBindingEditor.cs
+++ b/UnityWeld_Editor/TwoWayPropertyBindingEditor.cs
@@ -315,11 +315,11 @@ namespace UnityWeld_Editor
             {
                 switch (property.name)
                 {
-                    case "uiEventName":
+                    case "viewEventName":
                         viewEventPrefabModified = property.prefabOverride;
                         break;
 
-                    case "uiPropertyName":
+                    case "viewPropertyName":
                         viewPropertyPrefabModified = property.prefabOverride;
                         break;
 

--- a/UnityWeld_Editor/TwoWayPropertyBindingEditor.cs
+++ b/UnityWeld_Editor/TwoWayPropertyBindingEditor.cs
@@ -37,15 +37,18 @@ namespace UnityWeld_Editor
             targetScript = (TwoWayPropertyBinding)target;
 
             Type adapterType;
-            viewAdapterOptionsFade = new AnimBool(
-                ShouldShowAdapterOptions(targetScript.ViewAdapterTypeName, out adapterType)
-            );
-            viewModelAdapterOptionsFade = new AnimBool(
-                ShouldShowAdapterOptions(targetScript.ViewModelAdapterTypeName, out adapterType)
-            );
-            exceptionAdapterOptionsFade = new AnimBool(
-                ShouldShowAdapterOptions(targetScript.ExceptionAdapterTypeName, out adapterType)
-            );
+            viewAdapterOptionsFade = new AnimBool(ShouldShowAdapterOptions(
+                targetScript.ViewAdapterTypeName, 
+                out adapterType
+            ));
+            viewModelAdapterOptionsFade = new AnimBool(ShouldShowAdapterOptions(
+                targetScript.ViewModelAdapterTypeName, 
+                out adapterType
+            ));
+            exceptionAdapterOptionsFade = new AnimBool(ShouldShowAdapterOptions(
+                targetScript.ExceptionAdapterTypeName, 
+                out adapterType
+            ));
 
             viewAdapterOptionsFade.valueChanged.AddListener(Repaint);
             viewModelAdapterOptionsFade.valueChanged.AddListener(Repaint);
@@ -65,7 +68,9 @@ namespace UnityWeld_Editor
 
             var defaultLabelStyle = EditorStyles.label.fontStyle;
 
-            EditorStyles.label.fontStyle = viewEventPrefabModified ? FontStyle.Bold : defaultLabelStyle;
+            EditorStyles.label.fontStyle = viewEventPrefabModified 
+                ? FontStyle.Bold 
+                : defaultLabelStyle;
 
             ShowEventMenu(
                 UnityEventWatcher.GetBindableEvents(targetScript.gameObject)
@@ -75,7 +80,9 @@ namespace UnityWeld_Editor
                 targetScript.ViewEventName
             );
 
-            EditorStyles.label.fontStyle = viewPropertyPrefabModified ? FontStyle.Bold : defaultLabelStyle;
+            EditorStyles.label.fontStyle = viewPropertyPrefabModified 
+                ? FontStyle.Bold 
+                : defaultLabelStyle;
 
             Type viewPropertyType;
             ShowViewPropertyMenu(
@@ -91,7 +98,8 @@ namespace UnityWeld_Editor
 
             // Don't let the user set other options until they've set the event and view property.
             var guiPreviouslyEnabled = GUI.enabled;
-            if (string.IsNullOrEmpty(targetScript.ViewEventName) || string.IsNullOrEmpty(targetScript.ViewPropertName))
+            if (string.IsNullOrEmpty(targetScript.ViewEventName) 
+                || string.IsNullOrEmpty(targetScript.ViewPropertName))
             {
                 GUI.enabled = false;
             }
@@ -101,10 +109,15 @@ namespace UnityWeld_Editor
                     TypeResolver.FindAdapterAttribute(type).OutputType == viewPropertyType
             );
 
-            EditorStyles.label.fontStyle = viewAdapterPrefabModified ? FontStyle.Bold : defaultLabelStyle;
+            EditorStyles.label.fontStyle = viewAdapterPrefabModified 
+                ? FontStyle.Bold 
+                : defaultLabelStyle;
 
             ShowAdapterMenu(
-                new GUIContent("View adapter", "Adapter that converts values sent from the view-model to the view."),
+                new GUIContent(
+                    "View adapter", 
+                    "Adapter that converts values sent from the view-model to the view."
+                ),
                 viewAdapterTypeNames,
                 targetScript.ViewAdapterTypeName,
                 newValue =>
@@ -125,10 +138,15 @@ namespace UnityWeld_Editor
                 }
             );
 
-            EditorStyles.label.fontStyle = viewAdapterOptionsPrefabModified ? FontStyle.Bold : defaultLabelStyle;
+            EditorStyles.label.fontStyle = viewAdapterOptionsPrefabModified 
+                ? FontStyle.Bold 
+                : defaultLabelStyle;
 
             Type viewAdapterType;
-            viewAdapterOptionsFade.target = ShouldShowAdapterOptions(targetScript.ViewAdapterTypeName, out viewAdapterType);
+            viewAdapterOptionsFade.target = ShouldShowAdapterOptions(
+                targetScript.ViewAdapterTypeName, 
+                out viewAdapterType
+            );
             ShowAdapterOptionsMenu(
                 "View adapter options",
                 viewAdapterType,
@@ -139,11 +157,19 @@ namespace UnityWeld_Editor
 
             EditorGUILayout.Space();
 
-            EditorStyles.label.fontStyle = viewModelPropertyPrefabModified ? FontStyle.Bold : defaultLabelStyle;
+            EditorStyles.label.fontStyle = viewModelPropertyPrefabModified 
+                ? FontStyle.Bold 
+                : defaultLabelStyle;
 
-            var adaptedViewPropertyType = AdaptTypeBackward(viewPropertyType, targetScript.ViewAdapterTypeName);
+            var adaptedViewPropertyType = AdaptTypeBackward(
+                viewPropertyType, 
+                targetScript.ViewAdapterTypeName
+            );
             ShowViewModelPropertyMenu(
-                new GUIContent("View-model property", "Property on the view-model to bind to."),
+                new GUIContent(
+                    "View-model property", 
+                    "Property on the view-model to bind to."
+                ),
                 TypeResolver.FindBindableProperties(targetScript),
                 updatedValue => targetScript.ViewModelPropertyName = updatedValue,
                 targetScript.ViewModelPropertyName,
@@ -155,10 +181,15 @@ namespace UnityWeld_Editor
                     TypeResolver.FindAdapterAttribute(type).OutputType == adaptedViewPropertyType
             );
 
-            EditorStyles.label.fontStyle = viewModelAdapterPrefabModified ? FontStyle.Bold : defaultLabelStyle;
+            EditorStyles.label.fontStyle = viewModelAdapterPrefabModified 
+                ? FontStyle.Bold 
+                : defaultLabelStyle;
 
             ShowAdapterMenu(
-                new GUIContent("View-model adapter", "Adapter that converts from the view back to the view-model"),
+                new GUIContent(
+                    "View-model adapter", 
+                    "Adapter that converts from the view back to the view-model"
+                ),
                 viewModelAdapterTypeNames,
                 targetScript.ViewModelAdapterTypeName,
                 newValue =>
@@ -178,10 +209,15 @@ namespace UnityWeld_Editor
                 }
             );
 
-            EditorStyles.label.fontStyle = viewModelAdapterOptionsPrefabModified ? FontStyle.Bold : defaultLabelStyle;
+            EditorStyles.label.fontStyle = viewModelAdapterOptionsPrefabModified 
+                ? FontStyle.Bold 
+                : defaultLabelStyle;
 
             Type viewModelAdapterType;
-            viewModelAdapterOptionsFade.target = ShouldShowAdapterOptions(targetScript.ViewModelAdapterTypeName, out viewModelAdapterType);
+            viewModelAdapterOptionsFade.target = ShouldShowAdapterOptions(
+                targetScript.ViewModelAdapterTypeName, 
+                out viewModelAdapterType
+            );
             ShowAdapterOptionsMenu(
                 "View-model adapter options",
                 viewModelAdapterType,
@@ -196,21 +232,34 @@ namespace UnityWeld_Editor
                 type => TypeResolver.FindAdapterAttribute(type).InputType == typeof(Exception)
             );
 
-            EditorStyles.label.fontStyle = exceptionPropertyPrefabModified ? FontStyle.Bold : defaultLabelStyle;
+            EditorStyles.label.fontStyle = exceptionPropertyPrefabModified 
+                ? FontStyle.Bold 
+                : defaultLabelStyle;
 
-            var adaptedExceptionPropertyType = AdaptTypeForward(typeof(Exception), targetScript.ExceptionAdapterTypeName);
+            var adaptedExceptionPropertyType = AdaptTypeForward(
+                typeof(Exception), 
+                targetScript.ExceptionAdapterTypeName
+            );
             ShowViewModelPropertyMenuWithNone(
-                new GUIContent("Exception property", "Property on the view-model to bind the exception to."),
+                new GUIContent(
+                    "Exception property", 
+                    "Property on the view-model to bind the exception to."
+                ),
                 TypeResolver.FindBindableProperties(targetScript),
                 updatedValue => targetScript.ExceptionPropertyName = updatedValue,
                 targetScript.ExceptionPropertyName,
                 prop => prop.PropertyType == adaptedExceptionPropertyType
             );
 
-            EditorStyles.label.fontStyle = exceptionAdapterPrefabModified ? FontStyle.Bold : defaultLabelStyle;
+            EditorStyles.label.fontStyle = exceptionAdapterPrefabModified 
+                ? FontStyle.Bold 
+                : defaultLabelStyle;
 
             ShowAdapterMenu(
-                new GUIContent("Exception adapter", "Adapter that handles exceptions thrown by the view-model adapter"),
+                new GUIContent(
+                    "Exception adapter", 
+                    "Adapter that handles exceptions thrown by the view-model adapter"
+                ),
                 expectionAdapterTypeNames,
                 targetScript.ExceptionAdapterTypeName,
                 newValue =>
@@ -230,10 +279,15 @@ namespace UnityWeld_Editor
                 }
             );
 
-            EditorStyles.label.fontStyle = exceptionAdapterOptionsPrefabModified ? FontStyle.Bold : defaultLabelStyle;
+            EditorStyles.label.fontStyle = exceptionAdapterOptionsPrefabModified 
+                ? FontStyle.Bold 
+                : defaultLabelStyle;
 
             Type exceptionAdapterType;
-            exceptionAdapterOptionsFade.target = ShouldShowAdapterOptions(targetScript.ExceptionAdapterTypeName, out exceptionAdapterType);
+            exceptionAdapterOptionsFade.target = ShouldShowAdapterOptions(
+                targetScript.ExceptionAdapterTypeName, 
+                out exceptionAdapterType
+            );
             ShowAdapterOptionsMenu(
                 "Exception adapter options",
                 exceptionAdapterType,
@@ -248,7 +302,8 @@ namespace UnityWeld_Editor
         }
 
         /// <summary>
-        /// Check whether each of the properties on the object have been changed from the value in the prefab.
+        /// Check whether each of the properties on the object have been changed 
+        /// from the value in the prefab.
         /// </summary>
         private void UpdatePrefabModifiedProperties()
         {


### PR DESCRIPTION
Fixed issues where certain fields in many classes wouldn't be shown as bold in the editor after they'd been modified.

Added support for AdapterOptions to ToggleActiveBinding editor.

Replaced public fields in AbstractTemplateSelector with properties.

Cleaned up formatting (long lines)