### PR TITLE
Binding to types that cast implicitly

### DIFF
--- a/UnityWeld/Binding/Internal/PropertyEndPoint.cs
+++ b/UnityWeld/Binding/Internal/PropertyEndPoint.cs
@@ -77,10 +77,9 @@ namespace UnityWeld.Binding.Internal
             if (adapter != null)
             {
                 //Because C# uses the same syntax for unboxing & casting, We have to change the boxed type first just incase we are casting
-                var adapterAttributes = adapter.GetType().GetCustomAttributes(typeof(AdapterAttribute), false);
-                if (adapterAttributes.Length > 0)
+                var adapterAttribute = TypeResolver.FindAdapterAttribute(adapter.GetType());
+                if (adapterAttribute != null)
                 {
-                    var adapterAttribute = (AdapterAttribute)(adapterAttributes[0]);
                     try
                     {
                         input = Convert.ChangeType(input, adapterAttribute.InputType);

--- a/UnityWeld/Binding/Internal/PropertyEndPoint.cs
+++ b/UnityWeld/Binding/Internal/PropertyEndPoint.cs
@@ -96,7 +96,7 @@ namespace UnityWeld.Binding.Internal
             }
 
             //Fixing the boxed type again
-            var propertyType = property.GetValue(propertyOwner, null).GetType();
+            var propertyType = property.PropertyType;
             try
             {
                 input = Convert.ChangeType(input, propertyType);

--- a/UnityWeld/Binding/Internal/PropertyEndPoint.cs
+++ b/UnityWeld/Binding/Internal/PropertyEndPoint.cs
@@ -76,6 +76,22 @@ namespace UnityWeld.Binding.Internal
 
             if (adapter != null)
             {
+                //Because C# uses the same syntax for unboxing & casting, We have to change the boxed type first just incase we are casting
+                var adapterAttributes = adapter.GetType().GetCustomAttributes(typeof(AdapterAttribute), false);
+                if (adapterAttributes.Length > 0)
+                {
+                    var adapterAttribute = (AdapterAttribute)(adapterAttributes[0]);
+                    try
+                    {
+                        input = Convert.ChangeType(input, adapterAttribute.InputType);
+                    }
+                    catch(Exception ex)
+                    {
+                        Debug.LogError(string.Format("Failed to convert value from {0} to {1}.", input.GetType(), adapterAttribute.InputType));
+                        Debug.LogException(ex);
+                    }
+                }
+
                 input = adapter.Convert(input, adapterOptions);
             }
 

--- a/UnityWeld/Binding/Internal/PropertyEndPoint.cs
+++ b/UnityWeld/Binding/Internal/PropertyEndPoint.cs
@@ -85,7 +85,7 @@ namespace UnityWeld.Binding.Internal
                     {
                         input = Convert.ChangeType(input, adapterAttribute.InputType);
                     }
-                    catch(Exception ex)
+                    catch (Exception ex)
                     {
                         Debug.LogError(string.Format("Failed to convert value from {0} to {1}.", input.GetType(), adapterAttribute.InputType));
                         Debug.LogException(ex);
@@ -93,6 +93,18 @@ namespace UnityWeld.Binding.Internal
                 }
 
                 input = adapter.Convert(input, adapterOptions);
+            }
+
+            //Fixing the boxed type again
+            var propertyType = property.GetValue(propertyOwner, null).GetType();
+            try
+            {
+                input = Convert.ChangeType(input, propertyType);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError(string.Format("Failed to convert value from {0} to {1}.", input.GetType(), propertyType));
+                Debug.LogException(ex);
             }
 
             property.SetValue(propertyOwner, input, null);

--- a/UnityWeld/Binding/Internal/TypeResolver.cs
+++ b/UnityWeld/Binding/Internal/TypeResolver.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -276,6 +276,55 @@ namespace UnityWeld.Binding.Internal
                 .Where(p => typeof(IEnumerable).IsAssignableFrom(p.Member.PropertyType))
                 .Where(p => !typeof(string).IsAssignableFrom(p.Member.PropertyType))
                 .ToArray();
+        }
+
+        /// <summary>
+        /// Returns whether the Type from is castable to Type to
+        /// 
+        /// Found on: https://stackoverflow.com/questions/2119441/check-if-types-are-castable-subclasses
+        /// </summary>
+        public static bool IsTypeCastableTo(Type from, Type to, bool implicitly = false)
+        {
+            return to.IsAssignableFrom(from) || HasCastDefined(from, to, implicitly);
+        }
+
+        private static bool HasCastDefined(Type from, Type to, bool implicitly)
+        {
+            if ((from.IsPrimitive || from.IsEnum) && (to.IsPrimitive || to.IsEnum))
+            {
+                if (!implicitly)
+                    return from == to || (from != typeof(Boolean) && to != typeof(Boolean));
+
+                Type[][] typeHierarchy = {
+                    new Type[] { typeof(Byte),  typeof(SByte), typeof(Char) },
+                    new Type[] { typeof(Int16), typeof(UInt16) },
+                    new Type[] { typeof(Int32), typeof(UInt32) },
+                    new Type[] { typeof(Int64), typeof(UInt64) },
+                    new Type[] { typeof(Single) },
+                    new Type[] { typeof(Double) }
+                };
+                IEnumerable<Type> lowerTypes = Enumerable.Empty<Type>();
+                foreach (Type[] types in typeHierarchy)
+                {
+                    if (types.Any(t => t == to))
+                        return lowerTypes.Any(t => t == from);
+                    lowerTypes = lowerTypes.Concat(types);
+                }
+
+                return false;   // IntPtr, UIntPtr, Enum, Boolean
+            }
+            return IsCastDefined(to, m => m.GetParameters()[0].ParameterType, _ => from, implicitly, false)
+                || IsCastDefined(from, _ => to, m => m.ReturnType, implicitly, true);
+        }
+
+        private static bool IsCastDefined(Type type, Func<MethodInfo, Type> baseType,
+                                Func<MethodInfo, Type> derivedType, bool implicitly, bool lookInBase)
+        {
+            var bindinFlags = BindingFlags.Public | BindingFlags.Static
+                            | (lookInBase ? BindingFlags.FlattenHierarchy : BindingFlags.DeclaredOnly);
+            return type.GetMethods(bindinFlags).Any(
+                m => (m.Name == "op_Implicit" || (!implicitly && m.Name == "op_Explicit"))
+                    && baseType(m).IsAssignableFrom(derivedType(m)));
         }
     }
 }

--- a/UnityWeld_Editor/AnimatorParameterBindingEditor.cs
+++ b/UnityWeld_Editor/AnimatorParameterBindingEditor.cs
@@ -82,7 +82,8 @@ namespace UnityWeld_Editor
 
             var viewAdapterTypeNames = GetAdapterTypeNames(
                 type => viewPropertyType == null ||
-                    TypeResolver.FindAdapterAttribute(type).OutputType == viewPropertyType
+                    TypeResolver.FindAdapterAttribute(type).OutputType == viewPropertyType ||
+                    TypeResolver.IsTypeCastableTo(TypeResolver.FindAdapterAttribute(type).OutputType, viewPropertyType, true)
             );
 
             EditorStyles.label.fontStyle = viewAdapterPrefabModified ? FontStyle.Bold : defaultLabelStyle;
@@ -132,7 +133,8 @@ namespace UnityWeld_Editor
                 TypeResolver.FindBindableProperties(targetScript),
                 updatedValue => targetScript.ViewModelPropertyName = updatedValue,
                 targetScript.ViewModelPropertyName,
-                property => property.PropertyType == adaptedViewPropertyType
+                property => property.PropertyType == adaptedViewPropertyType ||
+                TypeResolver.IsTypeCastableTo(property.PropertyType, adaptedViewPropertyType, true)
             );
 
             GUI.enabled = guiPreviouslyEnabled;

--- a/UnityWeld_Editor/AnimatorParameterBindingEditor.cs
+++ b/UnityWeld_Editor/AnimatorParameterBindingEditor.cs
@@ -82,8 +82,7 @@ namespace UnityWeld_Editor
 
             var viewAdapterTypeNames = GetAdapterTypeNames(
                 type => viewPropertyType == null ||
-                    TypeResolver.FindAdapterAttribute(type).OutputType == viewPropertyType ||
-                    TypeResolver.IsTypeCastableTo(TypeResolver.FindAdapterAttribute(type).OutputType, viewPropertyType, true)
+                    TypeResolver.IsTypeCastableTo(TypeResolver.FindAdapterAttribute(type).OutputType, viewPropertyType)
             );
 
             EditorStyles.label.fontStyle = viewAdapterPrefabModified ? FontStyle.Bold : defaultLabelStyle;
@@ -133,8 +132,7 @@ namespace UnityWeld_Editor
                 TypeResolver.FindBindableProperties(targetScript),
                 updatedValue => targetScript.ViewModelPropertyName = updatedValue,
                 targetScript.ViewModelPropertyName,
-                property => property.PropertyType == adaptedViewPropertyType ||
-                TypeResolver.IsTypeCastableTo(property.PropertyType, adaptedViewPropertyType, true)
+                property => TypeResolver.IsTypeCastableTo(property.PropertyType, adaptedViewPropertyType)
             );
 
             GUI.enabled = guiPreviouslyEnabled;

--- a/UnityWeld_Editor/OneWayPropertyBindingEditor.cs
+++ b/UnityWeld_Editor/OneWayPropertyBindingEditor.cs
@@ -74,8 +74,9 @@ namespace UnityWeld_Editor
             }
 
             var viewAdapterTypeNames = GetAdapterTypeNames(
-                type => viewPropertyType == null || 
-                    TypeResolver.FindAdapterAttribute(type).OutputType == viewPropertyType
+                type => viewPropertyType == null ||
+                    TypeResolver.FindAdapterAttribute(type).OutputType == viewPropertyType ||
+                    TypeResolver.IsTypeCastableTo(TypeResolver.FindAdapterAttribute(type).OutputType, viewPropertyType, true)
             );
 
             EditorStyles.label.fontStyle = viewAdapterPrefabModified 
@@ -143,7 +144,8 @@ namespace UnityWeld_Editor
                 TypeResolver.FindBindableProperties(targetScript),
                 updatedValue => targetScript.ViewModelPropertyName = updatedValue,
                 targetScript.ViewModelPropertyName,
-                property => property.PropertyType == adaptedViewPropertyType
+                property => property.PropertyType == adaptedViewPropertyType ||
+                TypeResolver.IsTypeCastableTo(property.PropertyType, adaptedViewPropertyType, true)
             );
 
             GUI.enabled = guiPreviouslyEnabled;

--- a/UnityWeld_Editor/OneWayPropertyBindingEditor.cs
+++ b/UnityWeld_Editor/OneWayPropertyBindingEditor.cs
@@ -75,8 +75,7 @@ namespace UnityWeld_Editor
 
             var viewAdapterTypeNames = GetAdapterTypeNames(
                 type => viewPropertyType == null ||
-                    TypeResolver.FindAdapterAttribute(type).OutputType == viewPropertyType ||
-                    TypeResolver.IsTypeCastableTo(TypeResolver.FindAdapterAttribute(type).OutputType, viewPropertyType, true)
+                    TypeResolver.IsTypeCastableTo(TypeResolver.FindAdapterAttribute(type).OutputType, viewPropertyType)
             );
 
             EditorStyles.label.fontStyle = viewAdapterPrefabModified 
@@ -144,8 +143,7 @@ namespace UnityWeld_Editor
                 TypeResolver.FindBindableProperties(targetScript),
                 updatedValue => targetScript.ViewModelPropertyName = updatedValue,
                 targetScript.ViewModelPropertyName,
-                property => property.PropertyType == adaptedViewPropertyType ||
-                TypeResolver.IsTypeCastableTo(property.PropertyType, adaptedViewPropertyType, true)
+                property => TypeResolver.IsTypeCastableTo(property.PropertyType, adaptedViewPropertyType)
             );
 
             GUI.enabled = guiPreviouslyEnabled;

--- a/UnityWeld_Editor/ToggleActiveBindingEditor.cs
+++ b/UnityWeld_Editor/ToggleActiveBindingEditor.cs
@@ -52,8 +52,7 @@ namespace UnityWeld_Editor
 
             var viewAdapterTypeNames = GetAdapterTypeNames(
                 type => viewPropertyType == null ||
-                    TypeResolver.FindAdapterAttribute(type).OutputType == viewPropertyType ||
-                    TypeResolver.IsTypeCastableTo(TypeResolver.FindAdapterAttribute(type).OutputType, viewPropertyType, true)
+                    TypeResolver.IsTypeCastableTo(TypeResolver.FindAdapterAttribute(type).OutputType, viewPropertyType)
             );
 
             EditorStyles.label.fontStyle = viewAdapterPrefabModified
@@ -121,8 +120,7 @@ namespace UnityWeld_Editor
                 TypeResolver.FindBindableProperties(targetScript),
                 updatedValue => targetScript.ViewModelPropertyName = updatedValue,
                 targetScript.ViewModelPropertyName,
-                property => property.PropertyType == adaptedViewPropertyType ||
-                TypeResolver.IsTypeCastableTo(property.PropertyType, adaptedViewPropertyType, true) 
+                property => TypeResolver.IsTypeCastableTo(property.PropertyType, adaptedViewPropertyType) 
             );
 
             EditorStyles.label.fontStyle = defaultLabelStyle;

--- a/UnityWeld_Editor/ToggleActiveBindingEditor.cs
+++ b/UnityWeld_Editor/ToggleActiveBindingEditor.cs
@@ -52,7 +52,8 @@ namespace UnityWeld_Editor
 
             var viewAdapterTypeNames = GetAdapterTypeNames(
                 type => viewPropertyType == null ||
-                    TypeResolver.FindAdapterAttribute(type).OutputType == viewPropertyType
+                    TypeResolver.FindAdapterAttribute(type).OutputType == viewPropertyType ||
+                    TypeResolver.IsTypeCastableTo(TypeResolver.FindAdapterAttribute(type).OutputType, viewPropertyType, true)
             );
 
             EditorStyles.label.fontStyle = viewAdapterPrefabModified
@@ -120,7 +121,8 @@ namespace UnityWeld_Editor
                 TypeResolver.FindBindableProperties(targetScript),
                 updatedValue => targetScript.ViewModelPropertyName = updatedValue,
                 targetScript.ViewModelPropertyName,
-                property => property.PropertyType == adaptedViewPropertyType
+                property => property.PropertyType == adaptedViewPropertyType ||
+                TypeResolver.IsTypeCastableTo(property.PropertyType, adaptedViewPropertyType, true) 
             );
 
             EditorStyles.label.fontStyle = defaultLabelStyle;

--- a/UnityWeld_Editor/TwoWayPropertyBindingEditor.cs
+++ b/UnityWeld_Editor/TwoWayPropertyBindingEditor.cs
@@ -111,7 +111,8 @@ namespace UnityWeld_Editor
 
             var viewAdapterTypeNames = GetAdapterTypeNames(
                 type => viewPropertyType == null ||
-                    TypeResolver.FindAdapterAttribute(type).OutputType == viewPropertyType
+                    TypeResolver.FindAdapterAttribute(type).OutputType == viewPropertyType ||
+                    TypeResolver.IsTypeCastableTo(TypeResolver.FindAdapterAttribute(type).OutputType, viewPropertyType, true)
             );
 
             EditorStyles.label.fontStyle = viewAdapterPrefabModified 
@@ -178,12 +179,14 @@ namespace UnityWeld_Editor
                 TypeResolver.FindBindableProperties(targetScript),
                 updatedValue => targetScript.ViewModelPropertyName = updatedValue,
                 targetScript.ViewModelPropertyName,
-                prop => prop.PropertyType == adaptedViewPropertyType
+                prop => prop.PropertyType == adaptedViewPropertyType ||
+                TypeResolver.IsTypeCastableTo(prop.PropertyType, adaptedViewPropertyType, true)
             );
 
             var viewModelAdapterTypeNames = GetAdapterTypeNames(
                 type => adaptedViewPropertyType == null ||
-                    TypeResolver.FindAdapterAttribute(type).OutputType == adaptedViewPropertyType
+                    TypeResolver.FindAdapterAttribute(type).OutputType == adaptedViewPropertyType ||
+                    TypeResolver.IsTypeCastableTo(TypeResolver.FindAdapterAttribute(type).OutputType, adaptedViewPropertyType, true)
             );
 
             EditorStyles.label.fontStyle = viewModelAdapterPrefabModified 
@@ -234,7 +237,8 @@ namespace UnityWeld_Editor
             EditorGUILayout.Space();
 
             var expectionAdapterTypeNames = GetAdapterTypeNames(
-                type => TypeResolver.FindAdapterAttribute(type).InputType == typeof(Exception)
+                type => TypeResolver.FindAdapterAttribute(type).InputType == typeof(Exception) ||
+                TypeResolver.IsTypeCastableTo(TypeResolver.FindAdapterAttribute(type).InputType, typeof(Exception), true)
             );
 
             EditorStyles.label.fontStyle = exceptionPropertyPrefabModified 
@@ -253,7 +257,8 @@ namespace UnityWeld_Editor
                 TypeResolver.FindBindableProperties(targetScript),
                 updatedValue => targetScript.ExceptionPropertyName = updatedValue,
                 targetScript.ExceptionPropertyName,
-                prop => prop.PropertyType == adaptedExceptionPropertyType
+                prop => prop.PropertyType == adaptedExceptionPropertyType ||
+                TypeResolver.IsTypeCastableTo(prop.PropertyType, adaptedExceptionPropertyType, true)
             );
 
             EditorStyles.label.fontStyle = exceptionAdapterPrefabModified 

--- a/UnityWeld_Editor/TwoWayPropertyBindingEditor.cs
+++ b/UnityWeld_Editor/TwoWayPropertyBindingEditor.cs
@@ -111,8 +111,7 @@ namespace UnityWeld_Editor
 
             var viewAdapterTypeNames = GetAdapterTypeNames(
                 type => viewPropertyType == null ||
-                    TypeResolver.FindAdapterAttribute(type).OutputType == viewPropertyType ||
-                    TypeResolver.IsTypeCastableTo(TypeResolver.FindAdapterAttribute(type).OutputType, viewPropertyType, true)
+                    TypeResolver.IsTypeCastableTo(TypeResolver.FindAdapterAttribute(type).OutputType, viewPropertyType)
             );
 
             EditorStyles.label.fontStyle = viewAdapterPrefabModified 
@@ -179,14 +178,12 @@ namespace UnityWeld_Editor
                 TypeResolver.FindBindableProperties(targetScript),
                 updatedValue => targetScript.ViewModelPropertyName = updatedValue,
                 targetScript.ViewModelPropertyName,
-                prop => prop.PropertyType == adaptedViewPropertyType ||
-                TypeResolver.IsTypeCastableTo(prop.PropertyType, adaptedViewPropertyType, true)
+                prop => TypeResolver.IsTypeCastableTo(prop.PropertyType, adaptedViewPropertyType)
             );
 
             var viewModelAdapterTypeNames = GetAdapterTypeNames(
                 type => adaptedViewPropertyType == null ||
-                    TypeResolver.FindAdapterAttribute(type).OutputType == adaptedViewPropertyType ||
-                    TypeResolver.IsTypeCastableTo(TypeResolver.FindAdapterAttribute(type).OutputType, adaptedViewPropertyType, true)
+                    TypeResolver.IsTypeCastableTo(adaptedViewPropertyType, TypeResolver.FindAdapterAttribute(type).OutputType)
             );
 
             EditorStyles.label.fontStyle = viewModelAdapterPrefabModified 
@@ -237,8 +234,7 @@ namespace UnityWeld_Editor
             EditorGUILayout.Space();
 
             var expectionAdapterTypeNames = GetAdapterTypeNames(
-                type => TypeResolver.FindAdapterAttribute(type).InputType == typeof(Exception) ||
-                TypeResolver.IsTypeCastableTo(TypeResolver.FindAdapterAttribute(type).InputType, typeof(Exception), true)
+                type => TypeResolver.IsTypeCastableTo(TypeResolver.FindAdapterAttribute(type).InputType, typeof(Exception))
             );
 
             EditorStyles.label.fontStyle = exceptionPropertyPrefabModified 
@@ -257,8 +253,7 @@ namespace UnityWeld_Editor
                 TypeResolver.FindBindableProperties(targetScript),
                 updatedValue => targetScript.ExceptionPropertyName = updatedValue,
                 targetScript.ExceptionPropertyName,
-                prop => prop.PropertyType == adaptedExceptionPropertyType ||
-                TypeResolver.IsTypeCastableTo(prop.PropertyType, adaptedExceptionPropertyType, true)
+                prop => TypeResolver.IsTypeCastableTo(prop.PropertyType, adaptedExceptionPropertyType)
             );
 
             EditorStyles.label.fontStyle = exceptionAdapterPrefabModified 


### PR DESCRIPTION
This allows binding to types that can cast implicitly & works for adapters as well. PropertyEndPoint.SetValue() will convert the boxed types to the correct type aswell so nothing else needs to change and unboxing in adapters works as expected.

I tested this with the examples project and everything still seemed fine. I found no issues with using the casted binding aswell.

What do you guys think?