### PR TITLE
Added StringEmptyToBoolAdapter, minor fixes and cleanups

### DIFF
--- a/Unity-Weld.nuspec
+++ b/Unity-Weld.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>RSG.UnityWeld</id>
-    <version>0.7.1</version>
+    <version>0.7.2</version>
     <title>RSG.UnityWeld</title>
     <authors>Real Serious Games</authors>
     <owners>Real Serious Games</owners>

--- a/UnityWeld/Binding/AbstractTemplateSelector.cs
+++ b/UnityWeld/Binding/AbstractTemplateSelector.cs
@@ -90,17 +90,10 @@ namespace UnityWeld.Binding
 
         /// <summary>
         /// Create a clone of the template object and bind it to the specified view model.
+        /// Place the new object under the parent at the specified index, or 0 if no index
+        /// is specified.
         /// </summary>
-        protected void InstantiateTemplate(object templateViewModel)
-        {
-            InstantiateTemplate(templateViewModel, 0);
-        }
-
-        /// <summary>
-        /// Create a clone of the template object and bind it to the specified view model.
-        /// Place the new object under the parent at the specified index.
-        /// </summary>
-        protected void InstantiateTemplate(object templateViewModel, int index)
+        protected void InstantiateTemplate(object templateViewModel, int index = 0)
         {
             Assert.IsNotNull(templateViewModel, "Cannot instantiate child with null view model");
             
@@ -132,7 +125,7 @@ namespace UnityWeld.Binding
                 throw new TemplateNotFoundException("Could not find any template matching type " + templateType);
             }
 
-            var sorted = possibleMatches.OrderBy(m => m.Key);
+            var sorted = possibleMatches.OrderBy(m => m.Key).ToList();
             var selectedType = sorted.First();
 
             if (sorted.Skip(1).Any(m => m.Key == selectedType.Key))

--- a/UnityWeld/Binding/AbstractTemplateSelector.cs
+++ b/UnityWeld/Binding/AbstractTemplateSelector.cs
@@ -118,17 +118,18 @@ namespace UnityWeld.Binding
         /// </summary>
         private Template FindTemplateForType(Type templateType)
         {
-            var possibleMatches = FindTypesMatchingTemplate(templateType).ToList();
+            var possibleMatches = FindTypesMatchingTemplate(templateType)
+                .OrderBy(m => m.Key)
+                .ToList();
 
             if (!possibleMatches.Any())
             {
                 throw new TemplateNotFoundException("Could not find any template matching type " + templateType);
             }
 
-            var sorted = possibleMatches.OrderBy(m => m.Key).ToList();
-            var selectedType = sorted.First();
+            var selectedType = possibleMatches.First();
 
-            if (sorted.Skip(1).Any(m => m.Key == selectedType.Key))
+            if (possibleMatches.Skip(1).Any(m => m.Key == selectedType.Key))
             {
                 throw new AmbiguousTypeException("Multiple templates were found that match type " + templateType
                     + ". This can be caused by providing multiple templates that match types " + templateType

--- a/UnityWeld/Binding/Adapters/StringCultureToDateTimeAdapterOptions.cs
+++ b/UnityWeld/Binding/Adapters/StringCultureToDateTimeAdapterOptions.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using UnityEngine;
 
 namespace UnityWeld.Binding.Adapters

--- a/UnityWeld/Binding/Adapters/StringEmptyToBoolAdapter.cs
+++ b/UnityWeld/Binding/Adapters/StringEmptyToBoolAdapter.cs
@@ -1,0 +1,15 @@
+namespace UnityWeld.Binding.Adapters
+{
+    /// <summary>
+    /// String to bool adapter that returns false if the string is null or empty, 
+    /// otherwise true.
+    /// </summary>
+    [Adapter(typeof(string), typeof(bool))]
+    public class StringEmptyToBoolAdapter : IAdapter
+    {
+        public object Convert(object valueIn, AdapterOptions options)
+        {
+            return !string.IsNullOrEmpty((string)valueIn);
+        }
+    }
+}

--- a/UnityWeld/Binding/AnimatorParameterBinding.cs
+++ b/UnityWeld/Binding/AnimatorParameterBinding.cs
@@ -1,10 +1,6 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using UnityEngine;
 using UnityEngine.Assertions;
-using UnityEngine.Serialization;
 using UnityWeld.Binding.Internal;
 
 namespace UnityWeld.Binding

--- a/UnityWeld/Binding/AnimatorParameterBinding.cs
+++ b/UnityWeld/Binding/AnimatorParameterBinding.cs
@@ -171,7 +171,7 @@ namespace UnityWeld.Binding
                     propertyName = "TriggerParameter";
                     break;
                 default:
-                    throw new ArgumentOutOfRangeException("Unexpected animator parameter type");
+                    throw new IndexOutOfRangeException("Unexpected animator parameter type");
             }
 
             var viewModelEndPoint = MakeViewModelEndPoint(viewModelPropertyName, null, null);

--- a/UnityWeld/Binding/EventBinding.cs
+++ b/UnityWeld/Binding/EventBinding.cs
@@ -56,8 +56,13 @@ namespace UnityWeld.Binding
             ParseViewEndPointReference(viewEventName, out eventName, out view);
 
             eventWatcher = new UnityEventWatcher(view, eventName, 
-                () => viewModelMethod.Invoke(viewModel, new object[0])
-            );
+                () =>
+                {
+                    if (viewModelMethod != null)
+                    {
+                        viewModelMethod.Invoke(viewModel, new object[0]);
+                    }
+                });
         }
 
         public override void Disconnect()

--- a/UnityWeld/Binding/Internal/BindableMember.cs
+++ b/UnityWeld/Binding/Internal/BindableMember.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 
 namespace UnityWeld.Binding.Internal
@@ -9,12 +9,12 @@ namespace UnityWeld.Binding.Internal
     /// returning the type of the view model if the property or method was declared in an 
     /// interface that the view model inherits from.
     /// </summary>
-    public class BindableMember<MemberType> where MemberType : MemberInfo
+    public class BindableMember<TMemberType> where TMemberType : MemberInfo
     {
         /// <summary>
         /// The bindable member info (usually a PropertyInfo or MethodInfo)
         /// </summary>
-        public readonly MemberType Member;
+        public readonly TMemberType Member;
 
         /// <summary>
         /// View model that the property or method belongs to.
@@ -43,7 +43,7 @@ namespace UnityWeld.Binding.Internal
             }
         }
 
-        public BindableMember(MemberType member, Type viewModelType)
+        public BindableMember(TMemberType member, Type viewModelType)
         {
             Member = member;
             ViewModelType = viewModelType;

--- a/UnityWeld/Binding/Internal/TypeResolver.cs
+++ b/UnityWeld/Binding/Internal/TypeResolver.cs
@@ -300,7 +300,6 @@ namespace UnityWeld.Binding.Internal
                     new [] { typeof(Single) },
                     new [] { typeof(Double) }
                 };
-                IEnumerable<Type> lowerTypes = Enumerable.Empty<Type>();
 
                 return typeHierarchy.Any(types => types.Contains(to)) &&
                     typeHierarchy

--- a/UnityWeld/Binding/Internal/UnityEventBinder.cs
+++ b/UnityWeld/Binding/Internal/UnityEventBinder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using UnityEngine.Events;
 using UnityWeld.Binding.Exceptions;
@@ -18,9 +18,12 @@ namespace UnityWeld.Binding.Internal
         {
             // Note that to find the paramaters of events on the UI, we need to see what 
             // generic arguments were passed to the UnityEvent they inherit from.
-            var eventArgumentTypes = unityEvent.GetType().BaseType.GetGenericArguments();
+            var baseType = unityEvent.GetType().BaseType;
+            var eventArgumentTypes = baseType != null
+                ? baseType.GetGenericArguments()
+                : null;
 
-            if (!eventArgumentTypes.Any())
+            if (eventArgumentTypes == null || !eventArgumentTypes.Any())
             {
                 return new UnityEventBinder(unityEvent, action);
             }
@@ -28,7 +31,11 @@ namespace UnityWeld.Binding.Internal
             try
             {
                 var genericType = typeof(UnityEventBinder<>).MakeGenericType(eventArgumentTypes);
-                return (UnityEventBinderBase)Activator.CreateInstance(genericType, unityEvent, action);
+                return (UnityEventBinderBase)Activator.CreateInstance(
+                    genericType, 
+                    unityEvent, 
+                    action
+                );
             }
             catch (ArgumentException ex)
             {

--- a/UnityWeld/Binding/ObservableList.cs
+++ b/UnityWeld/Binding/ObservableList.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace UnityWeld.Binding
 {
-    public class ObservableList<T> : IList<T>, IList, INotifyCollectionChanged, ITypedList
+    public class ObservableList<T> : IList<T>, INotifyCollectionChanged, ITypedList
     {
         /// <summary>
         /// Inner (non-obsevable) list.

--- a/UnityWeld/Binding/SubViewModelBinding.cs
+++ b/UnityWeld/Binding/SubViewModelBinding.cs
@@ -1,4 +1,3 @@
-using System;
 using UnityEngine;
 using UnityWeld.Binding.Exceptions;
 using UnityWeld.Binding.Internal;

--- a/UnityWeld/Binding/TemplateBinding.cs
+++ b/UnityWeld/Binding/TemplateBinding.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Reflection;
 using UnityEngine;
 using UnityWeld.Binding.Exceptions;

--- a/UnityWeld/Binding/ToggleActiveBinding.cs
+++ b/UnityWeld/Binding/ToggleActiveBinding.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Linq;
 using UnityEngine;
-using UnityEngine.Assertions;
 using UnityWeld.Binding.Internal;
 
 namespace UnityWeld.Binding

--- a/UnityWeld/Properties/AssemblyInfo.cs
+++ b/UnityWeld/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.7.1.0")]
-[assembly: AssemblyFileVersion("0.7.1.0")]
+[assembly: AssemblyVersion("0.7.2")]
+[assembly: AssemblyFileVersion("0.7.2")]

--- a/UnityWeld/UnityWeld.csproj
+++ b/UnityWeld/UnityWeld.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Binding\Adapters\FloatToDateTimeAdapter.cs" />
     <Compile Include="Binding\Adapters\StringCultureToDateTimeAdapter.cs" />
     <Compile Include="Binding\Adapters\StringCultureToDateTimeAdapterOptions.cs" />
+    <Compile Include="Binding\Adapters\StringEmptyToBoolAdapter.cs" />
     <Compile Include="Binding\Adapters\StringToFloatAdapter.cs" />
     <Compile Include="Binding\Adapters\StringToIntAdapter.cs" />
     <Compile Include="Binding\AnimatorParameterBinding.cs" />

--- a/UnityWeld_Editor/AnimatorParameterBindingEditor.cs
+++ b/UnityWeld_Editor/AnimatorParameterBindingEditor.cs
@@ -54,7 +54,7 @@ namespace UnityWeld_Editor
 
             var animatorParameters = GetAnimatorParameters();
 
-            if (animatorParameters == null || animatorParameters.Count() <= 0)
+            if (animatorParameters == null || !animatorParameters.Any())
             {
                 EditorGUILayout.HelpBox("Animator has no parameters!", MessageType.Warning);
                 return;
@@ -151,7 +151,7 @@ namespace UnityWeld_Editor
             out Type selectedPropertyType
         )
         {
-            if(properties == null || properties.Count() <= 0)
+            if(properties == null || !properties.Any())
             {
                 selectedPropertyType = null;
                 return;
@@ -337,7 +337,7 @@ namespace UnityWeld_Editor
 
             public bool Equals(AnimatorParameterTypeAndName other)
             {
-                return other.Name == Name && other.Type == Type;
+                return other != null && other.Name == Name && other.Type == Type;
             }
         }
     }

--- a/UnityWeld_Editor/CollectionBindingEditor.cs
+++ b/UnityWeld_Editor/CollectionBindingEditor.cs
@@ -76,9 +76,6 @@ namespace UnityWeld_Editor
                     case "templatesRoot":
                         templatesRootPrefabModified = property.prefabOverride;
                         break;
-
-                    default:
-                        break;
                 }
             }
             while (property.Next(false));

--- a/UnityWeld_Editor/EventBindingEditor.cs
+++ b/UnityWeld_Editor/EventBindingEditor.cs
@@ -102,9 +102,6 @@ namespace UnityWeld_Editor
                     case "viewModelMethodName":
                         viewModelMethodPrefabModified = property.prefabOverride;
                         break;
-
-                    default:
-                        break;
                 }
             }
             while (property.Next(false));

--- a/UnityWeld_Editor/InspectorUtils.cs
+++ b/UnityWeld_Editor/InspectorUtils.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
@@ -76,9 +76,6 @@ namespace UnityWeld_Editor
                         GUIUtility.keyboardControl = controlId;
                         currentEvent.Use();
                     }
-                    break;
-
-                default:
                     break;
             }
         }

--- a/UnityWeld_Editor/OneWayPropertyBindingEditor.cs
+++ b/UnityWeld_Editor/OneWayPropertyBindingEditor.cs
@@ -180,9 +180,6 @@ namespace UnityWeld_Editor
                     case "viewPropertyName":
                         viewPropertyPrefabModified = property.prefabOverride;
                         break;
-
-                    default:
-                        break;
                 }
             }
             while (property.Next(false));

--- a/UnityWeld_Editor/Properties/AssemblyInfo.cs
+++ b/UnityWeld_Editor/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.7.1.0")]
-[assembly: AssemblyFileVersion("0.7.1.0")]
+[assembly: AssemblyVersion("0.7.2")]
+[assembly: AssemblyFileVersion("0.7.2")]

--- a/UnityWeld_Editor/SubViewModelBindingEditor.cs
+++ b/UnityWeld_Editor/SubViewModelBindingEditor.cs
@@ -52,8 +52,7 @@ namespace UnityWeld_Editor
                     targetScript.ViewModelPropertyName = updatedValue;
 
                     targetScript.ViewModelTypeName = bindableProperties
-                        .Where(prop => prop.ToString() == updatedValue)
-                        .Single()
+                        .Single(prop => prop.ToString() == updatedValue)
                         .Member.PropertyType.ToString();
                 },
                 targetScript.ViewModelPropertyName,
@@ -93,9 +92,6 @@ namespace UnityWeld_Editor
                     case "viewModelTypeName":
                         propertyPrefabModified = property.prefabOverride 
                             || propertyPrefabModified;
-                        break;
-
-                    default:
                         break;
                 }
             }

--- a/UnityWeld_Editor/TemplateBindingEditor.cs
+++ b/UnityWeld_Editor/TemplateBindingEditor.cs
@@ -86,9 +86,6 @@ namespace UnityWeld_Editor
                     case "templatesRoot":
                         templatesRootPrefabModified = property.prefabOverride;
                         break;
-
-                    default:
-                        break;
                 }
             }
             while (property.Next(false));

--- a/UnityWeld_Editor/ToggleActiveBindingEditor.cs
+++ b/UnityWeld_Editor/ToggleActiveBindingEditor.cs
@@ -3,7 +3,6 @@ using UnityEditor;
 using UnityEditor.AnimatedValues;
 using UnityEngine;
 using UnityWeld.Binding;
-using UnityWeld.Binding.Exceptions;
 using UnityWeld.Binding.Internal;
 
 namespace UnityWeld_Editor
@@ -48,11 +47,12 @@ namespace UnityWeld_Editor
 
             var defaultLabelStyle = EditorStyles.label.fontStyle;
 
-            Type viewPropertyType = typeof(bool);
+            var viewPropertyType = typeof(bool);
 
             var viewAdapterTypeNames = GetAdapterTypeNames(
-                type => viewPropertyType == null ||
-                    TypeResolver.IsTypeCastableTo(TypeResolver.FindAdapterAttribute(type).OutputType, viewPropertyType)
+                type => TypeResolver.IsTypeCastableTo(
+                    TypeResolver.FindAdapterAttribute(type).OutputType, viewPropertyType
+                )
             );
 
             EditorStyles.label.fontStyle = viewAdapterPrefabModified
@@ -146,9 +146,6 @@ namespace UnityWeld_Editor
 
                     case "viewModelPropertyName":
                         viewModelPropertyPrefabModified = property.prefabOverride;
-                        break;
-
-                    default:
                         break;
                 }
             }

--- a/UnityWeld_Editor/TwoWayPropertyBindingEditor.cs
+++ b/UnityWeld_Editor/TwoWayPropertyBindingEditor.cs
@@ -359,9 +359,6 @@ namespace UnityWeld_Editor
                     case "exceptionAdapterOptions":
                         exceptionAdapterOptionsPrefabModified = property.prefabOverride;
                         break;
-
-                    default:
-                        break;
                 }
             }
             while (property.Next(false));


### PR DESCRIPTION
StringEmptyToBoolAdapter turns a string to a bool, returning true when the string is not null or empty.

Cleanups and minor fixes: 
 - Added more null checks in places where it was suggested by Resharper in order to avoid possible NullReferenceExceptions. 
 - In AbstractTemplateSelector, fixed a possible multiple enumeration issue by calling ToList on the collection before it was used.
 - Throw IndexOutOfRangeException instead of ArgumentOutOfRangeException in AnimatorParameterBinding, because the value being checked was not a function argument.
 - Inconsistent naming - template type parameters should always start with 'T'
 - Replaced Linq `.Count() <= 0` with `! ...Any()`, because Any can early-out once it finds an element, but Count() must iterate through all elements.