### PR TITLE
Plugin-able dependency injection for adapters

### DIFF
--- a/UnityWeld/Binding/AbstractMemberBinding.cs
+++ b/UnityWeld/Binding/AbstractMemberBinding.cs
@@ -84,7 +84,7 @@ namespace UnityWeld.Binding
                 throw new InvalidAdapterException(string.Format("Type '{0}' does not implement IAdapter and cannot be used as an adapter.", adapterTypeName));
             }
 
-            return (IAdapter)Activator.CreateInstance(adapterType);
+            return AdapterResolver.CreateAdapter(adapterType);
         }
 
         /// <summary>

--- a/UnityWeld/Binding/Internal/AdapterResolver.cs
+++ b/UnityWeld/Binding/Internal/AdapterResolver.cs
@@ -8,7 +8,7 @@ namespace UnityWeld.Binding.Internal
     /// <summary>
     /// Helper class for creating adapters
     /// </summary>
-    public class AdapterResolver
+    public static class AdapterResolver
     {
         private static IWeldContainerIoC container;
 

--- a/UnityWeld/Binding/Internal/AdapterResolver.cs
+++ b/UnityWeld/Binding/Internal/AdapterResolver.cs
@@ -24,8 +24,14 @@ namespace UnityWeld.Binding.Internal
         private static void SetupWeldContainer()
         {
             var containerTypes = TypeResolver.TypesWithWeldContainerAttribute.Where(t => typeof(IWeldContainerIoC).IsAssignableFrom(t));
-            if (containerTypes.Any())
+            var containerTypesCount = containerTypes.Count();
+            if (containerTypesCount > 0)
             {
+                if(containerTypesCount > 1)
+                {
+                    UnityEngine.Debug.LogWarningFormat("You have multiple classes marked with the WeldContainer Attribute, only one can be used!");
+                }
+
                 var containerType = containerTypes.First();
 
                 var useableMethods = containerType.GetMethods(BindingFlags.Public | BindingFlags.Static)

--- a/UnityWeld/Binding/Internal/AdapterResolver.cs
+++ b/UnityWeld/Binding/Internal/AdapterResolver.cs
@@ -10,26 +10,18 @@ namespace UnityWeld.Binding.Internal
     /// </summary>
     public class AdapterResolver
     {
-        private static AdapterResolver _instance;
-        private static AdapterResolver Instance
-        {
-            get
-            {
-                if (_instance == null)
-                {
-                    _instance = new AdapterResolver();
-                }
-                return _instance;
-            }
-        }
+        private static IWeldContainerIoC _container;
 
         public static IAdapter CreateAdapter(Type adapterType)
         {
-            return Instance._container.Resolve<IAdapter>(adapterType);
+            if(_container == null)
+            {
+                SetupWeldContainer();
+            }
+            return _container.Resolve<IAdapter>(adapterType);
         }
 
-        private IWeldContainerIoC _container;
-        public AdapterResolver()
+        private static void SetupWeldContainer()
         {
             var containerTypes = TypeResolver.TypesWithWeldContainerAttribute.Where(t => typeof(IWeldContainerIoC).IsAssignableFrom(t));
             if (containerTypes.Any())
@@ -49,6 +41,10 @@ namespace UnityWeld.Binding.Internal
                     {
                         _container = Activator.CreateInstance(containerType) as IWeldContainerIoC;
                     }
+                }
+                else
+                {
+                    _container = Activator.CreateInstance(containerType) as IWeldContainerIoC;
                 }
             }
 

--- a/UnityWeld/Binding/Internal/AdapterResolver.cs
+++ b/UnityWeld/Binding/Internal/AdapterResolver.cs
@@ -10,15 +10,15 @@ namespace UnityWeld.Binding.Internal
     /// </summary>
     public class AdapterResolver
     {
-        private static IWeldContainerIoC _container;
+        private static IWeldContainerIoC container;
 
         public static IAdapter CreateAdapter(Type adapterType)
         {
-            if(_container == null)
+            if(container == null)
             {
                 SetupWeldContainer();
             }
-            return _container.Resolve<IAdapter>(adapterType);
+            return container.Resolve<IAdapter>(adapterType);
         }
 
         private static void SetupWeldContainer()
@@ -35,22 +35,22 @@ namespace UnityWeld.Binding.Internal
                     var methodInfo = useableMethods.First();
                     if (methodInfo != null)
                     {
-                        _container = methodInfo.Invoke(null, null) as IWeldContainerIoC;
+                        container = methodInfo.Invoke(null, null) as IWeldContainerIoC;
                     }
                     else
                     {
-                        _container = Activator.CreateInstance(containerType) as IWeldContainerIoC;
+                        container = Activator.CreateInstance(containerType) as IWeldContainerIoC;
                     }
                 }
                 else
                 {
-                    _container = Activator.CreateInstance(containerType) as IWeldContainerIoC;
+                    container = Activator.CreateInstance(containerType) as IWeldContainerIoC;
                 }
             }
 
-            if (_container == null)
+            if (container == null)
             {
-                _container = new DefaultWeldContainer();
+                container = new DefaultWeldContainer();
             }
         }
     }

--- a/UnityWeld/Binding/Internal/AdapterResolver.cs
+++ b/UnityWeld/Binding/Internal/AdapterResolver.cs
@@ -7,6 +7,9 @@ namespace UnityWeld.Binding.Internal
 {
     /// <summary>
     /// Helper class for creating adapters
+    /// 
+    /// Will resolve with a class marked by WeldContainerAttribute, if there is none it will fall back to using DefaultWeldContainer
+    /// If there are multiple classes marked with WeldContainerAttribute, its initial setup will throw an InvalidOperationException
     /// </summary>
     public static class AdapterResolver
     {
@@ -14,49 +17,43 @@ namespace UnityWeld.Binding.Internal
 
         public static IAdapter CreateAdapter(Type adapterType)
         {
-            if(container == null)
+            if (container == null)
             {
-                SetupWeldContainer();
+                container = SetupWeldContainer();
             }
             return container.Resolve<IAdapter>(adapterType);
         }
 
-        private static void SetupWeldContainer()
+        private static IWeldContainerIoC SetupWeldContainer()
         {
-            var containerTypes = TypeResolver.TypesWithWeldContainerAttribute.Where(t => typeof(IWeldContainerIoC).IsAssignableFrom(t));
-            var containerTypesCount = containerTypes.Count();
+            var containerTypes = TypeResolver.TypesWithWeldContainerAttribute.Where(t => typeof(IWeldContainerIoC).IsAssignableFrom(t)).ToList();
+            var containerTypesCount = containerTypes.Count;
             if (containerTypesCount > 0)
             {
-                if(containerTypesCount > 1)
+                if (containerTypesCount > 1)
                 {
-                    UnityEngine.Debug.LogWarningFormat("You have multiple classes marked with the WeldContainer Attribute, only one can be used!");
+                    throw new InvalidOperationException("You have multiple classes marked with the WeldContainer Attribute, only one can be used!");
                 }
 
-                var containerType = containerTypes.First();
+                var containerType = containerTypes[0];
 
                 var useableMethods = containerType.GetMethods(BindingFlags.Public | BindingFlags.Static)
                     .Where(mi => mi.GetCustomAttributes(typeof(WeldContainerAttribute), false).Any() && typeof(IWeldContainerIoC).IsAssignableFrom(mi.ReturnType));
-                if (useableMethods.Any())
+
+                var methodInfo = useableMethods.FirstOrDefault();
+
+                if (methodInfo != null)
                 {
-                    var methodInfo = useableMethods.First();
-                    if (methodInfo != null)
-                    {
-                        container = methodInfo.Invoke(null, null) as IWeldContainerIoC;
-                    }
-                    else
-                    {
-                        container = Activator.CreateInstance(containerType) as IWeldContainerIoC;
-                    }
+                    return methodInfo.Invoke(null, null) as IWeldContainerIoC;
                 }
                 else
                 {
-                    container = Activator.CreateInstance(containerType) as IWeldContainerIoC;
+                    return Activator.CreateInstance(containerType) as IWeldContainerIoC;
                 }
             }
-
-            if (container == null)
+            else
             {
-                container = new DefaultWeldContainer();
+                return new DefaultWeldContainer();
             }
         }
     }

--- a/UnityWeld/Binding/Internal/AdapterResolver.cs
+++ b/UnityWeld/Binding/Internal/AdapterResolver.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using UnityWeld.Ioc;
+
+namespace UnityWeld.Binding.Internal
+{
+    /// <summary>
+    /// Helper class for creating adapters
+    /// </summary>
+    public class AdapterResolver
+    {
+        private static AdapterResolver _instance;
+        private static AdapterResolver Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    _instance = new AdapterResolver();
+                }
+                return _instance;
+            }
+        }
+
+        public static IAdapter CreateAdapter(Type adapterType)
+        {
+            return Instance._container.Resolve<IAdapter>(adapterType);
+        }
+
+        private IWeldContainerIoC _container;
+        public AdapterResolver()
+        {
+            var containerTypes = TypeResolver.TypesWithWeldContainerAttribute.Where(t => typeof(IWeldContainerIoC).IsAssignableFrom(t));
+            if (containerTypes.Any())
+            {
+                var containerType = containerTypes.First();
+
+                var useableMethods = containerType.GetMethods(BindingFlags.Public | BindingFlags.Static)
+                    .Where(mi => mi.GetCustomAttributes(typeof(WeldContainerAttribute), false).Any() && typeof(IWeldContainerIoC).IsAssignableFrom(mi.ReturnType));
+                if (useableMethods.Any())
+                {
+                    var methodInfo = useableMethods.First();
+                    if (methodInfo != null)
+                    {
+                        _container = methodInfo.Invoke(null, null) as IWeldContainerIoC;
+                    }
+                    else
+                    {
+                        _container = Activator.CreateInstance(containerType) as IWeldContainerIoC;
+                    }
+                }
+            }
+
+            if (_container == null)
+            {
+                _container = new DefaultWeldContainer();
+            }
+        }
+    }
+}

--- a/UnityWeld/Binding/Internal/TypeResolver.cs
+++ b/UnityWeld/Binding/Internal/TypeResolver.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using UnityEngine;
 using UnityWeld.Binding.Exceptions;
+using UnityWeld.Ioc;
 
 namespace UnityWeld.Binding.Internal
 {
@@ -40,6 +41,20 @@ namespace UnityWeld.Binding.Internal
                 }
 
                 return typesWithAdapterAttribute;
+            }
+        }
+
+        private static Type[] typesWithWeldContainerAttribute;
+        public static IEnumerable<Type> TypesWithWeldContainerAttribute
+        {
+            get
+            {
+                if (typesWithWeldContainerAttribute == null)
+                {
+                    typesWithWeldContainerAttribute = FindTypesMarkedByAttribute(typeof(WeldContainerAttribute));
+                }
+
+                return typesWithWeldContainerAttribute;
             }
         }
 

--- a/UnityWeld/Ioc/DefaultWeldContainer.cs
+++ b/UnityWeld/Ioc/DefaultWeldContainer.cs
@@ -3,6 +3,10 @@ using UnityWeld.Binding;
 
 namespace UnityWeld.Ioc
 {
+    /// <summary>
+    /// Implementation of IWeldContainerIoC to be used by defaults if no other type has been specified by WeldContainerAttribute
+    /// This implementation only allows for IAdapter types with a constructor with no arguments
+    /// </summary>
     public class DefaultWeldContainer : IWeldContainerIoC
     {
         public T Resolve<T>() where T : IAdapter

--- a/UnityWeld/Ioc/DefaultWeldContainer.cs
+++ b/UnityWeld/Ioc/DefaultWeldContainer.cs
@@ -1,0 +1,18 @@
+using System;
+using UnityWeld.Binding;
+
+namespace UnityWeld.Ioc
+{
+    public class DefaultWeldContainer : IWeldContainerIoC
+    {
+        public T Resolve<T>() where T : IAdapter
+        {
+            return Activator.CreateInstance<T>();
+        }
+
+        public T Resolve<T>(Type type) where T : IAdapter
+        {
+            return (T)Activator.CreateInstance(type);
+        }
+    }
+}

--- a/UnityWeld/Ioc/DefaultWeldContainer.cs
+++ b/UnityWeld/Ioc/DefaultWeldContainer.cs
@@ -9,12 +9,12 @@ namespace UnityWeld.Ioc
     /// </summary>
     public class DefaultWeldContainer : IWeldContainerIoC
     {
-        public T Resolve<T>() where T : IAdapter
+        public T Resolve<T>() where T : class, IAdapter
         {
             return Activator.CreateInstance<T>();
         }
 
-        public T Resolve<T>(Type type) where T : IAdapter
+        public T Resolve<T>(Type type) where T : class, IAdapter
         {
             return (T)Activator.CreateInstance(type);
         }

--- a/UnityWeld/Ioc/IWeldContainerIoc.cs
+++ b/UnityWeld/Ioc/IWeldContainerIoc.cs
@@ -9,7 +9,7 @@ namespace UnityWeld.Ioc
     /// </summary>
     public interface IWeldContainerIoC
     {
-        T Resolve<T>() where T : IAdapter;
-        T Resolve<T>(Type type) where T : IAdapter;
+        T Resolve<T>() where T : class, IAdapter;
+        T Resolve<T>(Type type) where T : class, IAdapter;
     }
 }

--- a/UnityWeld/Ioc/IWeldContainerIoc.cs
+++ b/UnityWeld/Ioc/IWeldContainerIoc.cs
@@ -3,6 +3,10 @@ using UnityWeld.Binding;
 
 namespace UnityWeld.Ioc
 {
+    /// <summary>
+    /// Base type for weld containers, used by AdapterResolver to get the instance of adapters. Combine with the WeldContainerAttribute
+    /// to use your implementation instead of DefaultWeldContainer
+    /// </summary>
     public interface IWeldContainerIoC
     {
         T Resolve<T>() where T : IAdapter;

--- a/UnityWeld/Ioc/IWeldContainerIoc.cs
+++ b/UnityWeld/Ioc/IWeldContainerIoc.cs
@@ -1,0 +1,11 @@
+using System;
+using UnityWeld.Binding;
+
+namespace UnityWeld.Ioc
+{
+    public interface IWeldContainerIoC
+    {
+        T Resolve<T>() where T : IAdapter;
+        T Resolve<T>(Type type) where T : IAdapter;
+    }
+}

--- a/UnityWeld/Ioc/WeldContainerAttribute.cs
+++ b/UnityWeld/Ioc/WeldContainerAttribute.cs
@@ -2,6 +2,12 @@ using System;
 
 namespace UnityWeld.Ioc
 {
+    /// <summary>
+    /// Class use: Marks the class to be used as WeldContainer, and it will be responsible for creating the adapter instances
+    /// 
+    /// Method use: If the class also has the attribute, and this method returns IWeldContainerIoC or an inherting type, the returned value will be used as the
+    /// instance used by AdapterResolver
+    /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = false)]
     public class WeldContainerAttribute : Attribute
     {

--- a/UnityWeld/Ioc/WeldContainerAttribute.cs
+++ b/UnityWeld/Ioc/WeldContainerAttribute.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace UnityWeld.Ioc
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = false)]
+    public class WeldContainerAttribute : Attribute
+    {
+    }
+}

--- a/UnityWeld/UnityWeld.csproj
+++ b/UnityWeld/UnityWeld.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Binding\IAdapter.cs" />
     <Compile Include="Binding\IMemberBinding.cs" />
     <Compile Include="Binding\INotifyCollectionChanged.cs" />
+    <Compile Include="Binding\Internal\AdapterResolver.cs" />
     <Compile Include="Binding\Internal\BindableMember.cs" />
     <Compile Include="Binding\Internal\PropertyEndPoint.cs" />
     <Compile Include="Binding\Internal\PropertyFinder.cs" />
@@ -112,6 +113,9 @@
     <Compile Include="Binding\Template.cs" />
     <Compile Include="Binding\Adapters\BoolToStringAdapter.cs" />
     <Compile Include="Binding\Adapters\BoolToStringAdapterOptions.cs" />
+    <Compile Include="Ioc\DefaultWeldContainer.cs" />
+    <Compile Include="Ioc\IWeldContainerIoc.cs" />
+    <Compile Include="Ioc\WeldContainerAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Binding\AbstractTemplateSelector.cs" />
     <Compile Include="Widgets\DropdownAdapter.cs" />


### PR DESCRIPTION
This allows people to plug in their IoC dependency injection frameworks to work with adapters. This is something I've had to create for my own projects, and I figured it can be useful for the framework as a whole. It's out of the way so people who don't want custom DI for the adapters wont have to change a thing, and I created a "DefaultWeldContainer" that gets used by default that just does what was being done normally. When creating your own implementation of IWeldContainerIoc, if you want it to be used by weld, just mark the class with the [WeldContainer] attribute, and if you want to supply a specific instance of this class you can mark a static method with the same attribute that returns a IWeldContainerIoc (or an implementing class of it). If you have multiple classes marked with the attribute, it will output a warning in the console & use the first one it finds :)

Example usage using with Zenject:
 - Create the weld container:
![image](https://user-images.githubusercontent.com/10552305/36926157-e25d96c2-1e3b-11e8-8cb6-88f9e40a1e21.png)
 - Zenject installer:
![image](https://user-images.githubusercontent.com/10552305/36926174-f235a2ec-1e3b-11e8-88f1-af61e006c43b.png)
 - Inject into adapter like normal: 
![image](https://user-images.githubusercontent.com/10552305/36926193-148f8fc4-1e3c-11e8-9102-a792e8c5c04b.png)


Hope this helps :)