### PR TITLE
AddComponentMenu for #16

### DIFF
--- a/UnityWeld/Binding/AnimatorParameterBinding.cs
+++ b/UnityWeld/Binding/AnimatorParameterBinding.cs
@@ -11,6 +11,7 @@ namespace UnityWeld.Binding
     /// the parameter changes).
     /// </summary>
     [RequireComponent(typeof(Animator))]
+    [AddComponentMenu("Unity Weld/Animator Parameter Binding")]
     [HelpURL("https://github.com/Real-Serious-Games/Unity-Weld")]
     public class AnimatorParameterBinding : AbstractMemberBinding
     {

--- a/UnityWeld/Binding/CollectionBinding.cs
+++ b/UnityWeld/Binding/CollectionBinding.cs
@@ -14,6 +14,7 @@ namespace UnityWeld.Binding
     /// Creates and destroys child objects when items are added and removed from a 
     /// collection that implements INotifyCollectionChanged, like ObservableList.
     /// </summary>
+    [AddComponentMenu("Unity Weld/Collection Binding")]
     [HelpURL("https://github.com/Real-Serious-Games/Unity-Weld")]
     public class CollectionBinding : AbstractTemplateSelector
     {

--- a/UnityWeld/Binding/DropdownBinding.cs
+++ b/UnityWeld/Binding/DropdownBinding.cs
@@ -7,6 +7,7 @@ using UnityWeld.Binding.Internal;
 namespace UnityWeld.Binding
 {
     [RequireComponent(typeof(Dropdown))]
+    [AddComponentMenu("Unity Weld/Dropdown Binding")]
     [HelpURL("https://github.com/Real-Serious-Games/Unity-Weld")]
     public class DropdownBinding : AbstractMemberBinding
     {

--- a/UnityWeld/Binding/EventBinding.cs
+++ b/UnityWeld/Binding/EventBinding.cs
@@ -8,6 +8,7 @@ namespace UnityWeld.Binding
     /// <summary>
     /// Class for binding Unity UI events to methods in a view model.
     /// </summary>
+    [AddComponentMenu("Unity Weld/Event Binding")]
     [HelpURL("https://github.com/Real-Serious-Games/Unity-Weld")]
     public class EventBinding : AbstractMemberBinding
     {

--- a/UnityWeld/Binding/OneWayPropertyBinding.cs
+++ b/UnityWeld/Binding/OneWayPropertyBinding.cs
@@ -9,6 +9,7 @@ namespace UnityWeld.Binding
     /// and updating the UI accordingly (note that this does not update the view model when
     /// the UI changes).
     /// </summary>
+    [AddComponentMenu("Unity Weld/OneWay Property Binding")]
     [HelpURL("https://github.com/Real-Serious-Games/Unity-Weld")]
     public class OneWayPropertyBinding : AbstractMemberBinding
     {

--- a/UnityWeld/Binding/SubViewModelBinding.cs
+++ b/UnityWeld/Binding/SubViewModelBinding.cs
@@ -7,6 +7,7 @@ namespace UnityWeld.Binding
     /// <summary>
     /// Bind a sub-view model which is a property on another view model for use in the UI.
     /// </summary>
+    [AddComponentMenu("Unity Weld/SubViewModel Binding")]
     [HelpURL("https://github.com/Real-Serious-Games/Unity-Weld")]
     public class SubViewModelBinding : AbstractMemberBinding, IViewModelProvider
     {

--- a/UnityWeld/Binding/Template.cs
+++ b/UnityWeld/Binding/Template.cs
@@ -17,6 +17,7 @@ namespace UnityWeld.Binding
     /// <summary>
     /// Template for use in collection bindings.
     /// </summary>
+    [AddComponentMenu("Unity Weld/Template")]
     [HelpURL("https://github.com/Real-Serious-Games/Unity-Weld")]
     public class Template : MonoBehaviour, IViewModelProvider, ITemplate
     {

--- a/UnityWeld/Binding/TemplateBinding.cs
+++ b/UnityWeld/Binding/TemplateBinding.cs
@@ -8,6 +8,7 @@ namespace UnityWeld.Binding
     /// <summary>
     /// Binds to a view and instantiates a template based on the view type.
     /// </summary>
+    [AddComponentMenu("Unity Weld/Template Binding")]
     [HelpURL("https://github.com/Real-Serious-Games/Unity-Weld")]
     public class TemplateBinding : AbstractTemplateSelector
     {

--- a/UnityWeld/Binding/ToggleActiveBinding.cs
+++ b/UnityWeld/Binding/ToggleActiveBinding.cs
@@ -7,6 +7,7 @@ namespace UnityWeld.Binding
     /// Bind to a boolean property on the view model and turn all child objects on
     /// or off based on its value.
     /// </summary>
+    [AddComponentMenu("Unity Weld/ToggleActive Binding")]
     [HelpURL("https://github.com/Real-Serious-Games/Unity-Weld")]
     public class ToggleActiveBinding : AbstractMemberBinding
     {

--- a/UnityWeld/Binding/TwoWayPropertyBinding.cs
+++ b/UnityWeld/Binding/TwoWayPropertyBinding.cs
@@ -9,6 +9,7 @@ namespace UnityWeld.Binding
     /// and updating the UI accordingly. Also bind to a UnityEvent in the UI and update the
     /// view model when the event is triggered.
     /// </summary>
+    [AddComponentMenu("Unity Weld/TwoWay Property Binding")]
     [HelpURL("https://github.com/Real-Serious-Games/Unity-Weld")]
     public class TwoWayPropertyBinding : AbstractMemberBinding
     {


### PR DESCRIPTION
This PR moves all components from `Scripts/UnityWeld.Bindings` menu to `Unity Weld`, fix #16 

I didn't add an attribute for `Dropdown Adapter` since it's marked as `Obsolete`. It's still in `Scripts/UnityWeld.Widgets`.