### PR TITLE
[Need More Tests] Use RuntimeInitializeOnLoadMethod to call Init()

### DIFF
--- a/UnityWeld/Binding/AbstractMemberBinding.cs
+++ b/UnityWeld/Binding/AbstractMemberBinding.cs
@@ -175,10 +175,10 @@ namespace UnityWeld.Binding
         /// Standard MonoBehaviour awake message, do not call this explicitly.
         /// Initialises the binding.
         /// </summary>
-        protected void Awake()
-        {
-            Init();
-        }
+        //protected void Awake()
+        //{
+        //    Init();
+        //}
 
         /// <summary>
         /// Clean up when the game object is destroyed.

--- a/UnityWeld/Binding/AbstractMemberBinding.cs
+++ b/UnityWeld/Binding/AbstractMemberBinding.cs
@@ -28,11 +28,13 @@ namespace UnityWeld.Binding
         private object FindViewModel(string viewModelName)
         {
             var trans = transform;
+
             while (trans != null)
             {
                 var components = trans.GetComponents<MonoBehaviour>();
                 var monoBehaviourViewModel = components
                     .FirstOrDefault(component => component.GetType().ToString() == viewModelName);
+
                 if (monoBehaviourViewModel != null)
                 {
                     return monoBehaviourViewModel;
@@ -42,8 +44,8 @@ namespace UnityWeld.Binding
                     .Select(component => component as IViewModelProvider)
                     .Where(component => component != null)
                     .FirstOrDefault(
-                        viewModelBinding => viewModelBinding.GetViewModelTypeName() == viewModelName && 
-#pragma warning disable 252,253 // Warning says unintended reference comparison, but we do want to compare references
+                        viewModelBinding => viewModelBinding.GetViewModelTypeName() == viewModelName &&
+#pragma warning disable 252, 253 // Warning says unintended reference comparison, but we do want to compare references
                         (object)viewModelBinding != this
 #pragma warning restore 252,253
                     );
@@ -73,6 +75,7 @@ namespace UnityWeld.Binding
             }
 
             var adapterType = TypeResolver.FindAdapterType(adapterTypeName);
+
             if (adapterType == null)
             {
                 throw new NoSuchAdapterException(adapterTypeName);
@@ -106,6 +109,7 @@ namespace UnityWeld.Binding
         protected static void ParseEndPointReference(string endPointReference, out string memberName, out string typeName)
         {
             var lastPeriodIndex = endPointReference.LastIndexOf('.');
+
             if (lastPeriodIndex == -1)
             {
                 throw new InvalidEndPointException(
@@ -170,15 +174,6 @@ namespace UnityWeld.Binding
         /// Disconnect from all attached view models.
         /// </summary>
         public abstract void Disconnect();
-
-        /// <summary>
-        /// Standard MonoBehaviour awake message, do not call this explicitly.
-        /// Initialises the binding.
-        /// </summary>
-        //protected void Awake()
-        //{
-        //    Init();
-        //}
 
         /// <summary>
         /// Clean up when the game object is destroyed.

--- a/UnityWeld/Binding/ToggleSelfBinding.cs
+++ b/UnityWeld/Binding/ToggleSelfBinding.cs
@@ -1,0 +1,115 @@
+using UnityEngine;
+using UnityWeld.Binding.Internal;
+
+namespace UnityWeld.Binding
+{
+    /// <summary>
+    /// Bind to a boolean property on the view model and turn itself on
+    /// or off based on its value.
+    /// </summary>
+    [AddComponentMenu("Unity Weld/ToggleSelf Binding")]
+    [HelpURL("https://github.com/Real-Serious-Games/Unity-Weld")]
+    public class ToggleSelfBinding : AbstractMemberBinding
+    {
+        /// <summary>
+        /// Type of the adapter we're using to adapt between the view model property 
+        /// and view property.
+        /// </summary>
+        public string ViewAdapterTypeName
+        {
+            get { return viewAdapterTypeName; }
+            set { viewAdapterTypeName = value; }
+        }
+
+        [SerializeField]
+        private string viewAdapterTypeName;
+
+        /// <summary>
+        /// Options for adapting from the view model to the view property.
+        /// </summary>
+        public AdapterOptions ViewAdapterOptions
+        {
+            get { return viewAdapterOptions; }
+            set { viewAdapterOptions = value; }
+        }
+
+        [SerializeField]
+        private AdapterOptions viewAdapterOptions;
+
+        /// <summary>
+        /// Name of the property in the view model to bind.
+        /// </summary>
+        public string ViewModelPropertyName
+        {
+            get { return viewModelPropertyName; }
+            set { viewModelPropertyName = value; }
+        }
+
+        [SerializeField]
+        private string viewModelPropertyName;
+
+        /// <summary>
+        /// Watcher the view-model for changes that must be propagated to the view.
+        /// </summary>
+        private PropertyWatcher viewModelWatcher;
+
+        /// <summary>
+        /// Property for the propertySync to set in order to activate and deactivate all children
+        /// </summary>
+        public bool SelfActive
+        {
+            set
+            {
+                SetActive(value);
+            }
+        }
+        
+        /// <inheritdoc />
+        public override void Connect()
+        {
+            var viewModelEndPoint = MakeViewModelEndPoint(viewModelPropertyName, null, null);
+
+            var propertySync = new PropertySync(
+                // Source
+                viewModelEndPoint,
+
+                // Dest
+                new PropertyEndPoint(
+                    this,
+                    "SelfActive",
+                    CreateAdapter(viewAdapterTypeName),
+                    viewAdapterOptions,
+                    "view",
+                    this
+                ),
+
+                // Errors, exceptions and validation.
+                null, // Validation not needed
+
+                this
+            );
+
+            viewModelWatcher = viewModelEndPoint.Watch(
+                () => propertySync.SyncFromSource()
+            );
+
+            // Copy the initial value over from the view-model.
+            propertySync.SyncFromSource();
+        }
+
+        /// <inheritdoc />
+        public override void Disconnect()
+        {
+            if (viewModelWatcher != null)
+            {
+                viewModelWatcher.Dispose();
+                viewModelWatcher = null;
+            }
+        }
+
+        private void SetActive(bool active)
+        {
+            transform.gameObject.SetActive(active);
+        }
+    }
+}

--- a/UnityWeld/UnityWeld.csproj
+++ b/UnityWeld/UnityWeld.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Binding\SubViewModelBinding.cs" />
     <Compile Include="Binding\TemplateBinding.cs" />
     <Compile Include="Binding\ToggleActiveBinding.cs" />
+    <Compile Include="Binding\ToggleSelfBinding.cs" />
     <Compile Include="Binding\TwoWayPropertyBinding.cs" />
     <Compile Include="Binding\AbstractMemberBinding.cs" />
     <Compile Include="Binding\Internal\UnityEventBinder.cs" />
@@ -120,6 +121,7 @@
     <Compile Include="Ioc\WeldContainerAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Binding\AbstractTemplateSelector.cs" />
+    <Compile Include="WeldContext.cs" />
     <Compile Include="Widgets\DropdownAdapter.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/UnityWeld/WeldContext.cs
+++ b/UnityWeld/WeldContext.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityWeld.Binding;
+
+namespace UnityWeld
+{
+    /// <summary>
+    /// Initialize all bindings when scene loaded
+    /// </summary>
+    public static class WeldContext
+    {
+        /// <summary>
+        /// Automatically called before scene load
+        /// </summary>
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        public static void WeldContextStartup()
+        {
+            SceneManager.sceneLoaded += SceneManager_SceneLoaded;
+        }
+
+        static void SceneManager_SceneLoaded(Scene scene, LoadSceneMode mode)
+        {
+            foreach (var parentT in scene.GetRootGameObjects())
+            {
+                //Call Init() on all bindings
+                foreach (var binding in parentT.GetComponentsInChildren<AbstractMemberBinding>(true)) //including inactive GameObjects
+                {
+                    binding.Init();
+                }
+            }
+        }
+    }
+}

--- a/UnityWeld_Editor/ToggleSelfBindingEditor.cs
+++ b/UnityWeld_Editor/ToggleSelfBindingEditor.cs
@@ -1,0 +1,153 @@
+using System;
+using UnityEditor;
+using UnityEditor.AnimatedValues;
+using UnityEngine;
+using UnityWeld.Binding;
+using UnityWeld.Binding.Internal;
+
+namespace UnityWeld_Editor
+{
+    [CustomEditor(typeof(ToggleSelfBinding))]
+    public class ToggleSelfBindingEditor : BaseBindingEditor
+    {
+        private ToggleSelfBinding targetScript;
+
+        private AnimBool viewAdapterOptionsFade;
+
+        private bool viewAdapterPrefabModified;
+        private bool viewAdapterOptionsPrefabModified;
+        private bool viewModelPropertyPrefabModified;
+
+        private void OnEnable()
+        {
+            targetScript = (ToggleSelfBinding)target;
+
+            Type adapterType;
+
+            viewAdapterOptionsFade = new AnimBool(
+                ShouldShowAdapterOptions(targetScript.ViewAdapterTypeName, out adapterType)
+            );
+
+            viewAdapterOptionsFade.valueChanged.AddListener(Repaint);
+        }
+
+        private void OnDisable()
+        {
+            viewAdapterOptionsFade.valueChanged.RemoveListener(Repaint);
+        }
+
+        public override void OnInspectorGUI()
+        {
+            if (CannotModifyInPlayMode())
+            {
+                GUI.enabled = false;
+            }
+
+            UpdatePrefabModifiedProperties();
+
+            var defaultLabelStyle = EditorStyles.label.fontStyle;
+
+            var viewPropertyType = typeof(bool);
+
+            var viewAdapterTypeNames = GetAdapterTypeNames(
+                type => TypeResolver.FindAdapterAttribute(type).OutputType == viewPropertyType
+            );
+
+            EditorStyles.label.fontStyle = viewAdapterPrefabModified
+                ? FontStyle.Bold
+                : defaultLabelStyle;
+
+            ShowAdapterMenu(
+                new GUIContent(
+                    "View adapter",
+                    "Adapter that converts values sent from the view-model to the view."
+                ),
+                viewAdapterTypeNames,
+                targetScript.ViewAdapterTypeName,
+                newValue =>
+                {
+                    // Get rid of old adapter options if we changed the type of the adapter.
+                    if (newValue != targetScript.ViewAdapterTypeName)
+                    {
+                        Undo.RecordObject(targetScript, "Set view adapter options");
+                        targetScript.ViewAdapterOptions = null;
+                    }
+
+                    UpdateProperty(
+                        updatedValue => targetScript.ViewAdapterTypeName = updatedValue,
+                        targetScript.ViewAdapterTypeName,
+                        newValue,
+                        "Set view adapter"
+                    );
+                }
+            );
+
+            Type adapterType;
+            viewAdapterOptionsFade.target = ShouldShowAdapterOptions(
+                targetScript.ViewAdapterTypeName,
+                out adapterType
+            );
+
+            EditorStyles.label.fontStyle = viewAdapterOptionsPrefabModified
+                ? FontStyle.Bold
+                : defaultLabelStyle;
+
+            ShowAdapterOptionsMenu(
+                "View adapter options",
+                adapterType,
+                options => targetScript.ViewAdapterOptions = options,
+                targetScript.ViewAdapterOptions,
+                viewAdapterOptionsFade.faded
+            );
+
+            EditorGUILayout.Space();
+
+            EditorStyles.label.fontStyle = viewModelPropertyPrefabModified
+                ? FontStyle.Bold
+                : defaultLabelStyle;
+
+            var adaptedViewPropertyType = AdaptTypeBackward(
+                viewPropertyType,
+                targetScript.ViewAdapterTypeName
+            );
+            ShowViewModelPropertyMenu(
+                new GUIContent(
+                    "View-model property",
+                    "Property on the view-model to bind to."
+                ),
+                TypeResolver.FindBindableProperties(targetScript),
+                updatedValue => targetScript.ViewModelPropertyName = updatedValue,
+                targetScript.ViewModelPropertyName,
+                property => property.PropertyType == adaptedViewPropertyType
+            );
+
+            EditorStyles.label.fontStyle = defaultLabelStyle;
+        }
+
+        private void UpdatePrefabModifiedProperties()
+        {
+            var property = serializedObject.GetIterator();
+            // Need to call Next(true) to get the first child. Once we have it, Next(false)
+            // will iterate through the properties.
+            property.Next(true);
+            do
+            {
+                switch (property.name)
+                {
+                    case "viewAdapterTypeName":
+                        viewAdapterPrefabModified = property.prefabOverride;
+                        break;
+
+                    case "viewAdapterOptions":
+                        viewAdapterOptionsPrefabModified = property.prefabOverride;
+                        break;
+
+                    case "viewModelPropertyName":
+                        viewModelPropertyPrefabModified = property.prefabOverride;
+                        break;
+                }
+            }
+            while (property.Next(false));
+        }
+    }
+}

--- a/UnityWeld_Editor/UnityWeld_Editor.csproj
+++ b/UnityWeld_Editor/UnityWeld_Editor.csproj
@@ -53,6 +53,7 @@
     <Compile Include="TemplateEditor.cs" />
     <Compile Include="TemplateBindingEditor.cs" />
     <Compile Include="ToggleActiveBindingEditor.cs" />
+    <Compile Include="ToggleSelfBindingEditor.cs" />
     <Compile Include="TwoWayPropertyBindingEditor.cs" />
     <Compile Include="EventBindingEditor.cs" />
     <Compile Include="InspectorUtils.cs" />


### PR DESCRIPTION
This PR implements the method mentioned by @MorganMoon at [here](https://github.com/Real-Serious-Games/Unity-Weld/issues/16#issuecomment-392889652).

It no longer uses `Awake()` for init, the new way is to find and init all bindings before scene loaded:

```
        static void SceneManager_SceneLoaded(Scene scene, LoadSceneMode mode)
        {
            foreach (var parentT in scene.GetRootGameObjects())
            {
                //Call Init() on all bindings
                foreach (var binding in parentT.GetComponentsInChildren<AbstractMemberBinding>(true)) //including inactive GameObjects
                {
                    binding.Init();
                }
            }
        }
```
By this way, we can implement `ToggleSelfBinding` which can toggle active for the gameobject it attached on, even if the gameobject is inactive at startup.

I have tested on Unity-Weld-Examples and all demos should still work. However I don't know if this will bring down the performance by traversing all gameojbects in scene. Maybe a performance test is needed .