### PR TITLE
[BUG FIX] Fixed editing of ExceptionProperty inside TwoWayPropertyBindingEditor

### DIFF
--- a/UnityWeld_Editor/BaseBindingEditor.cs
+++ b/UnityWeld_Editor/BaseBindingEditor.cs
@@ -160,7 +160,7 @@ namespace UnityWeld_Editor
                 option => UpdateProperty(
                     propertyValueSetter,
                     curPropertyValue,
-                    option.Property == null ? string.Empty : option.ToString(),
+                    option.Property == null ? string.Empty : option.Property.ToString(),
                     "Set view-model property"
                 ),
                 new[] { noneOption }


### PR DESCRIPTION
This is a small fix for a bug that happens when setting `ExceptionProperty` inside `TwoWayPropertyBinding`. It's currently using `option.ToString()`, which returns the default C# ToString() method for this class. The correct implementation should be `option.Property.ToString()`

Repro steps:
1 - Go to the validation example of Unity-Weld-Examples (inside 5_Validation).
2 - Go to the TwoWayPropertyBinding component inside `Canvas/InputField`
3 - Set ExceptionProperty value to None.
4 - Try set ExceptionProperty to `ValidationExample.ValidationViewModel.isValid`
5 - Note that the it sets the value to a weird value `UnityWeld-Editor.BaseBidningEditor+OptionInfo`. It will also throw an exception if you hit play.